### PR TITLE
feat: Add debug method to TypeSafeServiceProvider and TypeSafeService…

### DIFF
--- a/src/api/contracts/interfaces.ts
+++ b/src/api/contracts/interfaces.ts
@@ -224,4 +224,9 @@ export interface TypeSafeServiceLocator<TRegistry extends Record<string, any>> {
      * Disposes of all services and cleans up resources.
      */
     dispose(): void;
+
+    /**
+     * Prints a summary of registered services and their lifecycles.
+     */
+    debug(): void;
 }

--- a/src/api/type-safe-service-provider.ts
+++ b/src/api/type-safe-service-provider.ts
@@ -63,6 +63,15 @@ export class TypeSafeServiceProvider<TRegistry extends ServiceRegistry>
         });
     }
 
+    debug(): void {
+        console.log("--- Registered Services ---");
+        for (const [key, wrapper] of Object.entries(this.registrations)) {
+            const lifecycle = wrapper.getLifecycle();
+            console.log(`${key} -> [${lifecycle}]`);
+        }
+        console.log("-------------------------");
+    }
+
     private getTypeName<T>(keyOrType: ServiceKey<T>): string {
         return typeof keyOrType === "string" ? keyOrType : keyOrType.name;
     }

--- a/src/core/services/service-wrapper.ts
+++ b/src/core/services/service-wrapper.ts
@@ -50,6 +50,17 @@ export class ServiceWrapper {
     }
 
     /**
+     * Gets the lifecycle name.
+     * @returns The lifecycle name
+     */
+    getLifecycle(): string {
+        if (!this._lifecycle) {
+            return "Disposed";
+        }
+        return this._lifecycle.constructor.name.replace("Lifecycle", "");
+    }
+
+    /**
      * Creates a new scope for scoped services.
      * @returns A new ServiceWrapper instance for the new scope
      */

--- a/tests/debug.test.ts
+++ b/tests/debug.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi } from 'vitest';
+import { ContainerBuilder } from '../src/api/container-builder';
+
+class Service1 {}
+class Service2 {}
+class Service3 {}
+
+describe('Debug Method', () => {
+    it('should print registered services and their lifecycles', () => {
+        const container = new ContainerBuilder()
+            .registerSingleton('Service1', Service1)
+            .registerScoped('Service2', Service2)
+            .registerTransient('Service3', Service3)
+            .build();
+
+        const spy = vi.spyOn(console, 'log');
+
+        container.debug();
+
+        expect(spy).toHaveBeenCalledWith('--- Registered Services ---');
+        expect(spy).toHaveBeenCalledWith('Service1 -> [Singleton]');
+        expect(spy).toHaveBeenCalledWith('Service2 -> [Scoped]');
+        expect(spy).toHaveBeenCalledWith('Service3 -> [Transient]');
+        expect(spy).toHaveBeenCalledWith('-------------------------');
+
+        spy.mockRestore();
+    });
+});


### PR DESCRIPTION
This pull request introduces a new `debug` method to the service container system, enabling developers to print a summary of registered services and their lifecycles. This change improves observability and debugging capabilities for dependency injection.

### New Debugging Capability:

* **Interface Update**: Added the `debug` method to the `TypeSafeServiceLocator` interface to standardize the debugging functionality across service containers. (`src/api/contracts/interfaces.ts`, [src/api/contracts/interfaces.tsR227-R231](diffhunk://#diff-5669f2002eaa9c9aa0b369fb7c6c985520227d56f01f30abc34c67250350f534R227-R231))
* **Implementation**: Implemented the `debug` method in the `TypeSafeServiceProvider` class to log registered services and their lifecycles to the console. (`src/api/type-safe-service-provider.ts`, [src/api/type-safe-service-provider.tsR66-R74](diffhunk://#diff-c4af5d08025533cd5813a8bef94bec4363ed5782d3b6dacea81fbaa1de9a88f8R66-R74))

### Supporting Enhancements:

* **Lifecycle Retrieval**: Added a `getLifecycle` method to the `ServiceWrapper` class to retrieve the lifecycle name of a service (e.g., "Singleton", "Scoped", or "Transient"). This ensures accurate lifecycle information is displayed in the debug output. (`src/core/services/service-wrapper.ts`, [src/core/services/service-wrapper.tsR52-R62](diffhunk://#diff-3c1021fa6b262fc265af126afc99cb55632b3c3b5c33fcdfb0fe8b1e96580a6bR52-R62))

### Testing:

* **Unit Test**: Added a test suite for the `debug` method to verify that it correctly logs the registered services and their associated lifecycles. (`tests/debug.test.ts`, [tests/debug.test.tsR1-R28](diffhunk://#diff-7464fe201d261c0e0e33fccca985c8b975f7340bb0cebce8f495e6aa80d3e512R1-R28))…Locator for improved service registration visibility