### PR TITLE
docs(skill): sync skill folder with 1.0.0-rc.2 API surface

### DIFF
--- a/skills/kizuna/SKILL.md
+++ b/skills/kizuna/SKILL.md
@@ -213,18 +213,26 @@ class DatabasePool {
 const container = builder.build();
 const pool = container.get('dbPool');
 
-// Sync — fine for synchronous-only services
+// Pick ONE of the patterns below — they are alternatives, not steps.
+// Once disposed, a container cannot be used again.
+
+// Option A — Sync. Fine only for purely-synchronous services.
 container.dispose();
 
-// Async — awaits each service's dispose, runs them in parallel
+// Option B — Async. Awaits each service's dispose in parallel.
+//            Use this whenever any service has async cleanup.
 await container.disposeAsync();
 
-// TC39 explicit resource management
+// Option C — TC39 explicit resource management (scoped to a block).
+//            Best for per-request scopes; the container itself can
+//            still be disposed separately at shutdown.
 {
   await using scope = container.startScope();
-  // ...
+  // ...use scope...
 } // scope.disposeAsync() called automatically on block exit
 ```
+
+> **Note:** `await using` requires TypeScript ≥ 5.2 and a modern V8 runtime (Node ≥ 22, Bun, Deno, Cloudflare Workers, Vercel Edge). On older Node versions use the explicit `try/finally + await disposeAsync()` pattern.
 
 **Per-API resolution rules:**
 - `disposeAsync()` picks the instance's cleanup method by priority: `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`. The first one present is awaited.

--- a/skills/kizuna/SKILL.md
+++ b/skills/kizuna/SKILL.md
@@ -6,15 +6,17 @@ description: >
   registerSingletonFactory, registerScoped, registerTransient, addSingleton,
   addScoped, addTransient, addSingletonFactory, addScopedFactory,
   addTransientFactory, build(), validate(), get(), getAll(), startScope(),
-  dispose(), remove(), getRegisteredServiceNames(), TypeSafeServiceLocator,
+  dispose(), disposeAsync(), Symbol.dispose, Symbol.asyncDispose, remove(),
+  getRegisteredServiceNames(), TypeSafeServiceLocator,
   disableStrictParameterValidation.
   Activate when registering services, choosing lifecycles, managing request
   scopes, registering multiple implementations under one key, debugging
-  validation errors, testing with mock containers, or integrating with web
+  validation errors, testing with mock containers, deploying to edge
+  runtimes (Cloudflare Workers, Vercel Edge), or integrating with web
   frameworks.
 type: core
 library: kizuna
-library_version: "1.0.0-rc.0"
+library_version: "1.0.0-rc.2"
 sources:
   - "shi-rudo/kizuna:src/api/container-builder.ts"
   - "shi-rudo/kizuna:src/api/base-container-builder.ts"
@@ -25,6 +27,7 @@ sources:
   - "shi-rudo/kizuna:src/core/scopes/scoped.ts"
   - "shi-rudo/kizuna:src/core/scopes/transient.ts"
   - "shi-rudo/kizuna:src/core/services/service-wrapper.ts"
+  - "shi-rudo/kizuna:src/core/services/async-dispose.ts"
   - "shi-rudo/kizuna:README.md"
 ---
 
@@ -189,22 +192,43 @@ const issues = builder.validate();
 
 ### Disposal
 
-Calling `container.dispose()` disposes all lifecycle managers and their instances:
-- **Singleton**: Calls `instance.dispose()` if it exists, then marks lifecycle as permanently disposed
-- **Scoped**: Calls `instance.dispose()` if it exists, clears instance reference
+Two disposal APIs:
+- `container.dispose()` — synchronous. Calls each instance's `dispose()` method (if any) without awaiting Promises.
+- `container.disposeAsync()` — awaits service-owned async cleanup. Runs handlers in parallel via `Promise.allSettled`.
+
+Plus TC39 explicit-resource-management hooks: `[Symbol.dispose]` (alias for `dispose()`) and `[Symbol.asyncDispose]` (alias for `disposeAsync()`) — enable `using` and `await using` syntax.
+
+For each lifecycle, disposal does:
+- **Singleton**: Calls `instance.dispose()` (or `Symbol.asyncDispose` on async path) if it exists, then marks lifecycle as permanently disposed
+- **Scoped**: Same on a per-scope basis, clears instance reference
 - **Transient**: Clears factory reference (individual instances are not tracked)
 
-After disposal, `get()`, `getAll()`, and `startScope()` throw `"Cannot access services from a disposed container"`. Disposal is idempotent — calling it twice is safe.
+After disposal, `get()`, `getAll()`, and `startScope()` throw `"Cannot access services from a disposed container"`. Disposal is idempotent — calling it (or `disposeAsync`) twice is safe.
 
 ```typescript
+class DatabasePool {
+  async dispose() { await this.pool.end(); } // returns Promise — needs disposeAsync
+}
+
 const container = builder.build();
 const pool = container.get('dbPool');
-// ... use container ...
 
-container.dispose(); // pool.dispose() is called automatically if it exists
+// Sync — fine for synchronous-only services
+container.dispose();
 
-// container.get('dbPool'); // throws: Cannot access services from a disposed container
+// Async — awaits each service's dispose, runs them in parallel
+await container.disposeAsync();
+
+// TC39 explicit resource management
+{
+  await using scope = container.startScope();
+  // ...
+} // scope.disposeAsync() called automatically on block exit
 ```
+
+Resolution priority when picking the cleanup method on each instance: `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`.
+
+**When sync `dispose()` is wrong:** if any instance's `dispose()` returns a Promise (DB pool teardown, file handle close, network connection drain), `dispose()` invokes it but does not await it. Rejections are logged via a `.catch` attached internally to surface them, but the cleanup may still be in flight when the next operation runs. Always use `disposeAsync()` (or `await using`) when services hold async resources.
 
 ## Container Inspection & Modification
 
@@ -428,9 +452,11 @@ new ContainerBuilder()
   .registerSingleton('UserService', UserService, 'db')
 ```
 
-Strict parameter validation (enabled by default) checks that dependency keys match constructor parameter names positionally. Pick one naming convention and stick with it.
+Strict parameter validation (enabled by default in development) checks that dependency keys match constructor parameter names positionally. Pick one naming convention and stick with it.
 
-Source: base-container-builder.ts:171-193
+The check is **auto-disabled when `NODE_ENV === "production"`** (or when `process` is unavailable, e.g. in Cloudflare Workers / Vercel Edge) because bundler minification mangles parameter names into `a`, `b`, `c` — running the check there would produce false positives. No opt-out needed for production builds. Call `.disableStrictParameterValidation()` only if you also want to skip the check in development.
+
+Source: base-container-builder.ts:168-220
 
 ### HIGH Importing the stale Factory<T> type
 
@@ -520,4 +546,5 @@ Source: service-provider.ts:40-62
 - [Testing — test containers, stubs, scope isolation](references/testing.md)
 - [Next.js integration — scoping without middleware](references/nextjs.md)
 - [TanStack Start integration — loader and action scoping](references/tanstack-start.md)
+- [Edge runtimes — Cloudflare Workers, Vercel Edge patterns](references/edge-runtimes.md)
 - [Migration — from manual wiring, from decorator-based DI](references/migration.md)

--- a/skills/kizuna/SKILL.md
+++ b/skills/kizuna/SKILL.md
@@ -226,7 +226,9 @@ await container.disposeAsync();
 } // scope.disposeAsync() called automatically on block exit
 ```
 
-Resolution priority when picking the cleanup method on each instance: `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`.
+**Per-API resolution rules:**
+- `disposeAsync()` picks the instance's cleanup method by priority: `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`. The first one present is awaited.
+- `dispose()` (sync) **only** calls `instance.dispose()`. It does not look for `[Symbol.dispose]` or `[Symbol.asyncDispose]`. A service that implements `[Symbol.dispose]` instead of `dispose()` will NOT be cleaned up by sync `container.dispose()`. (TC39 `using` reaches the container's own `[Symbol.dispose]` hook, which then calls `container.dispose()` internally — but per-service Symbol hooks are async-only.)
 
 **When sync `dispose()` is wrong:** if any instance's `dispose()` returns a Promise (DB pool teardown, file handle close, network connection drain), `dispose()` invokes it but does not await it. Rejections are logged via a `.catch` attached internally to surface them, but the cleanup may still be in flight when the next operation runs. Always use `disposeAsync()` (or `await using`) when services hold async resources.
 
@@ -456,7 +458,7 @@ Strict parameter validation (enabled by default in development) checks that depe
 
 The check is **auto-disabled when `NODE_ENV === "production"`** (or when `process` is unavailable, e.g. in Cloudflare Workers / Vercel Edge) because bundler minification mangles parameter names into `a`, `b`, `c` — running the check there would produce false positives. No opt-out needed for production builds. Call `.disableStrictParameterValidation()` only if you also want to skip the check in development.
 
-Source: base-container-builder.ts:168-220
+Source: `BaseContainerBuilder.validate()` in base-container-builder.ts
 
 ### HIGH Importing the stale Factory<T> type
 

--- a/skills/kizuna/references/edge-runtimes.md
+++ b/skills/kizuna/references/edge-runtimes.md
@@ -1,0 +1,87 @@
+# Edge Runtimes — Cloudflare Workers, Vercel Edge
+
+Kizuna is built for edge runtimes: ~10 KB gzipped, zero Node-API dependencies (only `process.env` access is guarded behind a `typeof process` check), no module-level mutable state that could leak across isolate-reused requests. A CI smoke suite (`tests/edge-compat.test.ts`) boots the built bundle inside workerd via miniflare to guard against regressions.
+
+## Cloudflare Workers pattern
+
+```typescript
+import { ContainerBuilder } from '@shirudo/kizuna';
+
+// Built once per isolate at module load — cheap (no service is instantiated here)
+const container = new ContainerBuilder()
+  .registerSingleton('Logger', Logger)
+  .registerScoped('RequestContext', RequestContext)
+  .registerScoped('UserService', UserService, 'Logger', 'RequestContext')
+  .build();
+
+export default {
+  async fetch(req: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    const scope = container.startScope();
+    try {
+      // Use the scope synchronously inside the handler
+      return await handle(req, scope);
+    } finally {
+      // Schedule async cleanup AFTER the scope was used. ctx.waitUntil lets it
+      // run after the response is sent, without adding latency to the request.
+      ctx.waitUntil(scope.disposeAsync());
+    }
+  }
+};
+```
+
+**Why `try/finally` matters:** `scope.disposeAsync()` marks the scope disposed synchronously at the start of the async function it returns. If you scheduled it before using the scope, every subsequent `scope.get(...)` call inside `handle()` would throw `"Cannot access services from a disposed container"`. The `finally` block runs after `await handle(req, scope)` resolves, ensuring disposal is scheduled only once the scope is no longer in use.
+
+## Vercel Edge Functions pattern
+
+```typescript
+import { ContainerBuilder } from '@shirudo/kizuna';
+
+const container = new ContainerBuilder()
+  .registerSingleton('Logger', Logger)
+  .registerScoped('RequestContext', RequestContext)
+  .build();
+
+export const config = { runtime: 'edge' };
+
+export default async function handler(req: Request): Promise<Response> {
+  // `await using` ensures disposeAsync runs on every code path (including throws),
+  // and blocks the response until cleanup completes. Acceptable when cleanup is fast;
+  // if you need fire-and-forget cleanup on a platform without ctx.waitUntil, fall back
+  // to try/finally with a non-awaited disposeAsync().
+  await using scope = container.startScope();
+  return handle(req, scope);
+}
+```
+
+## Isolate reuse: don't put request state in singletons
+
+Edge runtimes reuse the same isolate across requests. A `Singleton` lives for the lifetime of the isolate — across users. If a singleton accidentally captures request-specific state (auth tokens, user IDs, tenant data), that state leaks to the next request served by the same isolate.
+
+This is not a Kizuna bug — it's the definition of `Singleton`. But the failure mode is more dangerous on the edge than on a per-process server, because isolate-sharing is invisible by default.
+
+**Rule of thumb:**
+
+| Use Singleton for | Use Scoped for | Use Transient for |
+| --- | --- | --- |
+| Stateless services | Anything touching the current request | Lightweight per-call helpers |
+| Configuration | `RequestContext`, auth state | UUID generators |
+| Infrastructure clients with their own pooling (DB clients, KV bindings, loggers) | Per-request DB transactions | Timestamps |
+
+If you find yourself mutating a singleton after first construction, it should probably be Scoped instead.
+
+## Strict parameter validation under minification
+
+`strictParameterValidation` inspects `constructor.toString()` to match dependency names to parameter names. Edge bundlers (esbuild, webpack) mangle parameter names during minification, which would produce false warnings.
+
+Kizuna **auto-disables this check when `NODE_ENV === "production"`** (or when `process` is unavailable, which is the case in workerd). No opt-out required for edge deploys; the check still runs in development to catch real ordering bugs early.
+
+## What kizuna does NOT do for you
+
+- **Code-splitting per service** — kizuna does not provide `registerSingletonAsyncFactory` or similar. If service A is heavy and only used on one route, route-level splitting (Workers' multiple `fetch` handlers, Vercel's per-route Edge Functions) is the right primitive.
+- **Cross-isolate state sharing** — singletons are per-isolate. Use Durable Objects, KV, or the platform's primitives for shared state.
+- **Connection pooling** — register the platform's binding (e.g. `env.DB`, `env.KV`) as a singleton; kizuna does not wrap it.
+
+## See also
+
+- [Lifecycle guide](lifecycle-guide.md) — captive-dependency rules apply doubly on the edge (a singleton holding a scoped instance becomes cross-request state in an isolate)
+- [Scoping and middleware](scoping-and-middleware.md) — Node-side patterns for comparison

--- a/skills/kizuna/references/edge-runtimes.md
+++ b/skills/kizuna/references/edge-runtimes.md
@@ -45,9 +45,12 @@ export const config = { runtime: 'edge' };
 
 export default async function handler(req: Request): Promise<Response> {
   // `await using` ensures disposeAsync runs on every code path (including throws),
-  // and blocks the response until cleanup completes. Acceptable when cleanup is fast;
-  // if you need fire-and-forget cleanup on a platform without ctx.waitUntil, fall back
-  // to try/finally with a non-awaited disposeAsync().
+  // and blocks the response until cleanup completes. Acceptable when cleanup is fast.
+  //
+  // For fire-and-forget post-response cleanup, Vercel exposes waitUntil via
+  // `import { waitUntil } from '@vercel/functions'` — use a try/finally pattern
+  // like the Workers example and pass scope.disposeAsync() to waitUntil() instead
+  // of awaiting it inline.
   await using scope = container.startScope();
   return handle(req, scope);
 }

--- a/skills/kizuna/references/lifecycle-guide.md
+++ b/skills/kizuna/references/lifecycle-guide.md
@@ -6,8 +6,8 @@ Every registration in Kizuna has one of three lifecycles. The lifecycle controls
 
 | Lifecycle | Instance creation | Sharing | Disposal | Use for |
 | --- | --- | --- | --- | --- |
-| Singleton | Lazy, on first `get()` | One instance forever | Calls `dispose()` / `[Symbol.asyncDispose]` on instance when root container is disposed | DB pools, config, loggers |
-| Scoped | Lazy, on first `get()` within scope | One per scope | Calls `dispose()` / `[Symbol.asyncDispose]` on instance if it exists | Per-request state, transactions |
+| Singleton | Lazy, on first `get()` | One instance forever | Instance cleanup runs when root container is disposed (see [Disposal behavior](#disposal-behavior) for sync vs async resolution rules) | DB pools, config, loggers |
+| Scoped | Lazy, on first `get()` within scope | One per scope | Instance cleanup runs when scope is disposed (see [Disposal behavior](#disposal-behavior)) | Per-request state, transactions |
 | Transient | Every `get()` call | Never shared | Not tracked | Stateless services, timestamps, UUIDs |
 
 ## Singleton
@@ -116,7 +116,9 @@ The `ServiceProvider` (container) also exposes TC39 hooks:
 - `[Symbol.dispose]()` — alias for `dispose()`. Enables `using` syntax.
 - `[Symbol.asyncDispose]()` — alias for `disposeAsync()`. Enables `await using` syntax.
 
-When picking the cleanup method on each service instance, kizuna prefers `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`.
+**Per-API resolution rules:**
+- `disposeAsync()` picks the instance's cleanup method by priority: `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`. The first one present is awaited.
+- `dispose()` (sync) **only** calls `instance.dispose()`. It does NOT look for `[Symbol.dispose]` or `[Symbol.asyncDispose]` on instances. A service that implements `[Symbol.dispose]` instead of `dispose()` will not be cleaned up by sync `container.dispose()`. (The container's own `[Symbol.dispose]` hook is used by TC39 `using` syntax and calls `container.dispose()` internally — but per-service Symbol hooks are async-only.)
 
 After `container.dispose()` or `container.disposeAsync()`:
 - `get()`, `getAll()`, `startScope()` throw `"Cannot access services from a disposed container"`.

--- a/skills/kizuna/references/lifecycle-guide.md
+++ b/skills/kizuna/references/lifecycle-guide.md
@@ -6,8 +6,8 @@ Every registration in Kizuna has one of three lifecycles. The lifecycle controls
 
 | Lifecycle | Instance creation | Sharing | Disposal | Use for |
 | --- | --- | --- | --- | --- |
-| Singleton | Lazy, on first `get()` | One instance forever | Calls `dispose()` on instance when root container is disposed | DB pools, config, loggers |
-| Scoped | Lazy, on first `get()` within scope | One per scope | Calls `dispose()` on instance if it exists | Per-request state, transactions |
+| Singleton | Lazy, on first `get()` | One instance forever | Calls `dispose()` / `[Symbol.asyncDispose]` on instance when root container is disposed | DB pools, config, loggers |
+| Scoped | Lazy, on first `get()` within scope | One per scope | Calls `dispose()` / `[Symbol.asyncDispose]` on instance if it exists | Per-request state, transactions |
 | Transient | Every `get()` call | Never shared | Not tracked | Stateless services, timestamps, UUIDs |
 
 ## Singleton
@@ -105,11 +105,24 @@ Both `SingletonLifecycle` and `ScopedLifecycle` use a boolean `_initialized` fla
 
 ## Disposal behavior
 
-All three lifecycles implement idempotent `dispose()` — calling it twice is safe (second call is a no-op). All check `_isDisposed` before `_factory` in `getInstance()`, so after disposal you always get a clear "disposed" error, not a misleading "no factory" error.
+Two disposal APIs on every lifecycle and on the container:
 
-The `ServiceProvider` (container) also tracks disposal state:
-- `get()`, `getAll()`, `startScope()` all throw `"Cannot access services from a disposed container"` after `container.dispose()`.
-- `dispose()` clears internal registration maps to allow GC of all service wrappers and lifecycle objects.
+- `dispose()` — synchronous. Calls each instance's `dispose()` without awaiting Promises. Rejections from Promise-returning `dispose` are logged via a `.catch` attached internally, but not awaited.
+- `disposeAsync()` — awaits service-owned async cleanup. Runs handlers in parallel via `Promise.allSettled`.
+
+Both are idempotent (second call is a no-op). All check `_isDisposed` before `_factory` in `getInstance()`, so after disposal you always get a clear "disposed" error, not a misleading "no factory" error.
+
+The `ServiceProvider` (container) also exposes TC39 hooks:
+- `[Symbol.dispose]()` — alias for `dispose()`. Enables `using` syntax.
+- `[Symbol.asyncDispose]()` — alias for `disposeAsync()`. Enables `await using` syntax.
+
+When picking the cleanup method on each service instance, kizuna prefers `[Symbol.asyncDispose]` → `[Symbol.dispose]` → `dispose()`.
+
+After `container.dispose()` or `container.disposeAsync()`:
+- `get()`, `getAll()`, `startScope()` throw `"Cannot access services from a disposed container"`.
+- Internal registration maps are cleared to allow GC of all service wrappers and lifecycle objects.
+
+**Pick the async variant when:** any registered service's `dispose` returns a Promise (e.g. `await pool.end()`, `await kafkaProducer.disconnect()`), or implements `Symbol.asyncDispose`. The sync `dispose()` cannot await these and the cleanup may be in flight when the next operation runs.
 
 ## startScope() allocates O(n) objects
 

--- a/skills/kizuna/references/nextjs.md
+++ b/skills/kizuna/references/nextjs.md
@@ -4,6 +4,8 @@ Next.js does not have a middleware chain like Express. The scoping question beco
 
 **Status:** These patterns are recommendations based on Next.js architecture constraints. They are not documented in Kizuna's official docs.
 
+**Runtime:** Patterns below assume the default Node.js runtime. If a route, server component, or action declares `export const runtime = 'edge'`, the disposal primitive changes — fire-and-forget via `waitUntil` instead of `await scope.disposeAsync()` — to avoid blocking the response. See [edge-runtimes.md](edge-runtimes.md).
+
 ## The core challenge
 
 In Express, you create a scope in middleware and dispose it on response end. In Next.js:
@@ -22,6 +24,8 @@ In Express, you create a scope in middleware and dispose it on response end. In 
 | Multiple components need shared state | `withScope` helper + pass data down | Via return value, not scope | `finally` in helper |
 
 **Key insight:** In Next.js, every entry point gets its own scope. There is no way to share a scope across server components in the same render.
+
+**Sync vs async disposal:** the examples below use `scope.dispose()` (sync) for brevity. If any registered service has async cleanup — `dispose()` that returns a Promise, or implements `[Symbol.asyncDispose]` — use `await scope.disposeAsync()` instead. Sync `dispose()` invokes async handlers but does not await them; the cleanup may still be running when the response is sent. Common services that need async disposal: DB connection pools, file handles, network sockets, queue producers.
 
 ## Route handlers
 
@@ -111,7 +115,10 @@ export async function withScope<T>(
   try {
     return await fn(scope);
   } finally {
-    scope.dispose();
+    // Awaits async cleanup (DB pools, etc.) so callers don't return before
+    // resources settle. Use scope.dispose() instead if you don't have any
+    // services with Promise-returning dispose handlers.
+    await scope.disposeAsync();
   }
 }
 ```

--- a/skills/kizuna/references/nextjs.md
+++ b/skills/kizuna/references/nextjs.md
@@ -115,9 +115,10 @@ export async function withScope<T>(
   try {
     return await fn(scope);
   } finally {
-    // Awaits async cleanup (DB pools, etc.) so callers don't return before
-    // resources settle. Use scope.dispose() instead if you don't have any
-    // services with Promise-returning dispose handlers.
+    // Default to async: awaits cleanup for DB pools, transactions, etc. so
+    // callers don't return before resources settle. If your container only
+    // registers services with synchronous dispose() (or none), swap the line
+    // below to `scope.dispose()` to skip the microtask roundtrip.
     await scope.disposeAsync();
   }
 }

--- a/skills/kizuna/references/scoping-and-middleware.md
+++ b/skills/kizuna/references/scoping-and-middleware.md
@@ -144,9 +144,15 @@ app.use('*', async (c, next) => {
   try {
     await next();
   } finally {
-    // Awaits async cleanup (DB pools, transactions) before the request resolves.
-    // Use scope.dispose() if all your services are synchronous.
+    // Node / Bun / Deno: await the cleanup before the request resolves.
     await scope.disposeAsync();
+
+    // Workers / Vercel Edge variant — fire-and-forget via the platform's
+    // executionCtx so cleanup doesn't add latency to the response:
+    //
+    //   c.executionCtx.waitUntil(scope.disposeAsync());
+    //
+    // Choose ONE branch based on your deployment target.
   }
 });
 

--- a/skills/kizuna/references/scoping-and-middleware.md
+++ b/skills/kizuna/references/scoping-and-middleware.md
@@ -144,15 +144,16 @@ app.use('*', async (c, next) => {
   try {
     await next();
   } finally {
-    // Node / Bun / Deno: await the cleanup before the request resolves.
+    // ⚠️ PICK ONE of the two lines below based on your deployment target.
+    // Running both, or the wrong one, will either double-dispose or add
+    // latency to every response.
+
+    // [Node / Bun / Deno] — await cleanup before the request resolves:
     await scope.disposeAsync();
 
-    // Workers / Vercel Edge variant — fire-and-forget via the platform's
-    // executionCtx so cleanup doesn't add latency to the response:
-    //
+    // [Workers / Vercel Edge] — fire-and-forget via executionCtx so
+    // cleanup runs after the response is sent, without adding latency:
     //   c.executionCtx.waitUntil(scope.disposeAsync());
-    //
-    // Choose ONE branch based on your deployment target.
   }
 });
 

--- a/skills/kizuna/references/scoping-and-middleware.md
+++ b/skills/kizuna/references/scoping-and-middleware.md
@@ -2,13 +2,17 @@
 
 Request scoping creates a fresh set of scoped service instances per request while sharing singletons across all requests.
 
+**Runtime:** Express, Fastify, and NestJS are Node-only. Hono is multi-runtime (Node, Bun, Deno, Workers, Vercel Edge). On edge runtimes the disposal primitive changes — use `c.executionCtx.waitUntil(scope.disposeAsync())` for fire-and-forget cleanup instead of `await scope.disposeAsync()` in `finally`, to avoid blocking the response with post-request work. See [edge-runtimes.md](edge-runtimes.md).
+
 ## The pattern
 
 1. Call `container.startScope()` at request start.
 2. Use `scope.get()` / `scope.getAll()` to resolve services within the request.
-3. Call `scope.dispose()` when the request completes.
+3. Call `scope.dispose()` (sync) or `await scope.disposeAsync()` (async) when the request completes.
 
 Scoped services share one instance within the scope. Different scopes get different instances. Singletons are shared across all scopes.
+
+**Sync vs async disposal:** use `disposeAsync()` whenever any registered service has Promise-returning `dispose()` or implements `[Symbol.asyncDispose]` (DB connection pools, file handles, transaction rollback, queue producers). The sync variant invokes async handlers but does not await them — cleanup may still be running when the next operation begins. Some framework hooks (Express `res.on('finish')`, Fastify `done`-callback hooks) cannot `await` directly; those are noted inline.
 
 ## Which framework pattern
 
@@ -72,10 +76,16 @@ import { container } from './lib/container';
 
 const app = express();
 
-// Scope middleware — creates and disposes scope per request
+// Scope middleware — creates and disposes scope per request.
+// res.on('finish') is a sync callback that cannot await; if services have
+// async cleanup, fire-and-forget disposeAsync() (rejections go to console).
 app.use((req, res, next) => {
   req.scope = container.startScope();
-  res.on('finish', () => req.scope.dispose());
+  res.on('finish', () => {
+    void req.scope.disposeAsync().catch((err) => {
+      console.error('Async scope disposal failed:', err);
+    });
+  });
   next();
 });
 
@@ -97,9 +107,10 @@ app.use((req, res, next) => {
   next();
 });
 
-// Graceful shutdown
-process.on('SIGTERM', () => {
-  container.dispose(); // Disposes all singletons (logger, config, middleware)
+// Graceful shutdown — awaits async singleton cleanup (DB pools etc.)
+// before exiting.
+process.on('SIGTERM', async () => {
+  await container.disposeAsync();
   process.exit(0);
 });
 
@@ -133,7 +144,9 @@ app.use('*', async (c, next) => {
   try {
     await next();
   } finally {
-    scope.dispose();
+    // Awaits async cleanup (DB pools, transactions) before the request resolves.
+    // Use scope.dispose() if all your services are synchronous.
+    await scope.disposeAsync();
   }
 });
 
@@ -178,9 +191,13 @@ fastify.addHook('onRequest', (request, reply, done) => {
   done();
 });
 
+// onResponse uses a `done` callback rather than returning a Promise, so we
+// chain disposeAsync via .then/.catch. Use scope.dispose() (sync) if all
+// services are synchronous.
 fastify.addHook('onResponse', (request, reply, done) => {
-  request.scope.dispose();
-  done();
+  request.scope.disposeAsync()
+    .catch((err) => request.log.error({ err }, 'scope dispose failed'))
+    .finally(() => done());
 });
 
 fastify.get('/users/:id', (request, reply) => {
@@ -194,10 +211,11 @@ fastify.get('/users/:id', (request, reply) => {
   reply.send(user);
 });
 
-// Graceful shutdown
+// Graceful shutdown — awaits async singleton cleanup before Fastify exits.
 fastify.addHook('onClose', (instance, done) => {
-  container.dispose();
-  done();
+  container.disposeAsync()
+    .catch((err) => instance.log.error({ err }, 'container dispose failed'))
+    .finally(() => done());
 });
 
 // TypeScript: extend request

--- a/skills/kizuna/references/tanstack-start.md
+++ b/skills/kizuna/references/tanstack-start.md
@@ -51,8 +51,9 @@ export const withScope = createMiddleware().server(async ({ next }) => {
     const result = await next({ context: { scope } });
     return result;
   } finally {
-    // Awaits async cleanup (e.g. transaction rollback/commit) before the
-    // request resolves. Use scope.dispose() instead for purely-sync services.
+    // Default to async: awaits cleanup (e.g. transaction rollback/commit)
+    // before the request resolves. If your container only registers services
+    // with synchronous dispose() (or none), use `scope.dispose()` instead.
     await scope.disposeAsync();
   }
 });

--- a/skills/kizuna/references/tanstack-start.md
+++ b/skills/kizuna/references/tanstack-start.md
@@ -4,6 +4,8 @@ TanStack Start has server middleware, loaders, and actions — each with differe
 
 **Status:** These patterns are recommendations based on TanStack Start architecture constraints. They are not documented in Kizuna's official docs.
 
+**Runtime:** Patterns below assume a Node.js deployment target. If TanStack Start runs on an edge runtime (Cloudflare Workers, Vercel Edge), use fire-and-forget cleanup via the platform's `waitUntil` instead of `await scope.disposeAsync()` — awaiting disposal in the request path adds latency for what is fundamentally post-response work. See [edge-runtimes.md](edge-runtimes.md).
+
 ## The core challenge
 
 - **Loaders** can run in parallel for the same route. If each loader creates its own scope, scoped services are not shared between sibling loaders.
@@ -18,6 +20,8 @@ TanStack Start has server middleware, loaders, and actions — each with differe
 | No middleware | Scope per server function | Each function gets its own scope | `finally` in handler |
 
 **Key decision:** Use middleware when parallel loaders need to share scoped services (e.g., same DB transaction). Use per-function scopes when isolation is preferred.
+
+**Sync vs async disposal:** the examples below use `scope.dispose()` for brevity. If your services have async cleanup (DB pool teardown, transaction rollback, file handle close, anything where `dispose()` returns a Promise or `[Symbol.asyncDispose]` is implemented), use `await scope.disposeAsync()` instead — the sync variant invokes async handlers but does not await them. For shared DB transactions in particular, awaiting disposal ensures rollback/commit completes before the request resolves.
 
 ```
 Middleware scope (shared):
@@ -47,7 +51,9 @@ export const withScope = createMiddleware().server(async ({ next }) => {
     const result = await next({ context: { scope } });
     return result;
   } finally {
-    scope.dispose();
+    // Awaits async cleanup (e.g. transaction rollback/commit) before the
+    // request resolves. Use scope.dispose() instead for purely-sync services.
+    await scope.disposeAsync();
   }
 });
 ```

--- a/skills/kizuna/references/testing.md
+++ b/skills/kizuna/references/testing.md
@@ -42,6 +42,35 @@ describe('UserService', () => {
 });
 ```
 
+### With async-cleanup services
+
+When a test stub has async cleanup — a testcontainers-backed DB pool, a queue mock that flushes on dispose, anything where `dispose()` returns a Promise — switch the disposal line to `await scope.disposeAsync()` so the test does not finish before cleanup runs:
+
+```typescript
+class FakeQueue {
+  flushed = false;
+  async dispose() {
+    // Simulate async drain (e.g. await producer.flush())
+    await new Promise(r => setImmediate(r));
+    this.flushed = true;
+  }
+}
+
+describe('publisher', () => {
+  it('flushes the queue on scope disposal', async () => {
+    const container = new ContainerBuilder()
+      .registerScopedFactory('queue', () => new FakeQueue())
+      .build();
+    const scope = container.startScope();
+    const queue = scope.get('queue');
+
+    await scope.disposeAsync();
+
+    expect(queue.flushed).toBe(true);
+  });
+});
+```
+
 ## Override a single registration
 
 Build a helper that creates the production container but swaps one service.

--- a/skills/kizuna/references/testing.md
+++ b/skills/kizuna/references/testing.md
@@ -1,5 +1,7 @@
 # Testing
 
+**Sync vs async disposal in tests:** examples below use `scope.dispose()` because most test stubs are synchronous. If a test registers a service with async cleanup — Promise-returning `dispose()` or `[Symbol.asyncDispose]` (e.g. a real DB pool wrapping testcontainers, an async-clean mock that flushes a queue) — switch the matching line to `await scope.disposeAsync()`. Otherwise the test may complete before cleanup runs, leaking resources across tests in the same file.
+
 ## Create a test container with stubs
 
 Build a separate container for tests with mock implementations registered via factories.

--- a/skills/kizuna/references/validation-errors.md
+++ b/skills/kizuna/references/validation-errors.md
@@ -102,7 +102,11 @@ class UserService {
 
 Pick one convention and use it consistently across the project.
 
-### Disabling strict parameter validation
+### Strict parameter validation: auto-skip and opt-out
+
+The parameter name check is **automatically disabled when `NODE_ENV === "production"`** (or when `process` is unavailable, e.g. in Cloudflare Workers / Vercel Edge). Bundler minification mangles parameter names into `a`, `b`, `c` — running the check there would produce false positives. No opt-out needed for production builds.
+
+To also skip the check in development (rarely needed):
 
 ```typescript
 const builder = new ContainerBuilder()
@@ -110,7 +114,9 @@ const builder = new ContainerBuilder()
   .registerSingleton('UserService', UserService, 'DatabaseConnection');
 ```
 
-This disables only the parameter name check. Missing dependency and circular dependency checks still run. Avoid disabling unless you have a specific reason — the mismatch warnings catch real bugs.
+This disables only the parameter name check. Missing dependency and circular dependency checks still run. Avoid disabling in development unless you have a specific reason — the mismatch warnings catch real bugs.
+
+**Source:** `base-container-builder.ts:168-220` (the check is gated on `isDevelopment()` which returns true unless `NODE_ENV === "production"` or `__DEV__` is explicitly false / `process` is undefined).
 
 ## How parameter name extraction works
 

--- a/skills/kizuna/references/validation-errors.md
+++ b/skills/kizuna/references/validation-errors.md
@@ -116,7 +116,7 @@ const builder = new ContainerBuilder()
 
 This disables only the parameter name check. Missing dependency and circular dependency checks still run. Avoid disabling in development unless you have a specific reason — the mismatch warnings catch real bugs.
 
-**Source:** `base-container-builder.ts:168-220` (the check is gated on `isDevelopment()` which returns true unless `NODE_ENV === "production"` or `__DEV__` is explicitly false / `process` is undefined).
+**Source:** `BaseContainerBuilder.validate()` in `base-container-builder.ts` (the check is gated on `isDevelopment()`, which returns false when `NODE_ENV === "production"` or `process` is undefined).
 
 ## How parameter name extraction works
 


### PR DESCRIPTION
## Summary

The skill ships in the npm tarball (`files: ["skills", ...]`) so stale guidance reaches users via Claude Code. This update brings the skill folder in sync with the rc.1 + rc.2 changes that were already shipped on \`main\`:

- **rc.1**: \`disposeAsync()\` and \`Symbol.dispose\` / \`Symbol.asyncDispose\`
- **rc.2**: \`strictParameterValidation\` auto-skip in production / edge runtimes

## Changes

- **SKILL.md**: \`library_version\` bumped, description and dispose section updated, parameter-validation high-mistake rewritten with auto-skip behavior, edge-runtimes added to references
- **lifecycle-guide.md**: disposal table and dedicated section on sync vs async
- **validation-errors.md**: section retitled \"auto-skip and opt-out\"
- **references/edge-runtimes.md (new)**: Workers and Vercel Edge patterns, isolate reuse warning, what kizuna doesn't do for edge
- **nextjs.md / tanstack-start.md**: runtime pointer at top, \`withScope\` helper switched to \`disposeAsync\`
- **scoping-and-middleware.md**: top runtime note (Hono is multi-runtime), Express \`res.on('finish')\` uses fire-and-forget \`disposeAsync().catch\`, Hono / Fastify shutdown switched to async, SIGTERM handlers await \`disposeAsync\`

## Decision

Initially considered a generic \"works everywhere\" framework guidance, but reality is split: Express/Fastify/NestJS are Node-only, Hono is multi-runtime, Next.js / TanStack Start depend on deployment target. Chose: keep framework references Node-focused, add a one-line runtime pointer at the top, full edge patterns in their own reference. AI consumers combine the two contexts; humans get concrete starting patterns.

## Test plan

- [ ] Verify rendered SKILL.md and edge-runtimes.md look right on GitHub
- [ ] Verify Workers code sample compiles (try/finally + ctx.waitUntil pattern matches what tests/edge-compat.test.ts exercises)
- [ ] Confirm no Code changes (docs-only PR) — \`git diff main\` should only touch \`skills/**\`