### PR TITLE
Release packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -5,6 +5,7 @@
     "@shirudo/kizuna": "1.0.0-rc.3"
   },
   "changesets": [
-    "quiet-tools-release"
+    "quiet-tools-release",
+    "strict-interface-keys"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-rc.5
+
+### Patch Changes
+
+- 5794d01: Require the literal service key when an interface registration uses explicit type arguments. This prevents the provider registry from widening to every string key. Update calls such as `registerSingletonInterface<ILogger>('logger', ConsoleLogger)` to `registerSingletonInterface<ILogger, 'logger'>('logger', ConsoleLogger)`.
+
 ## 1.0.0-rc.4
 
 ### Patch Changes

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@shirudo/kizuna",
-    "version": "1.0.0-rc.4",
+    "version": "1.0.0-rc.5",
     "description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
     "keywords": [
         "Dependency Injection",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shirudo/kizuna",
-	"version": "1.0.0-rc.4",
+	"version": "1.0.0-rc.5",
 	"description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- release `@shirudo/kizuna` 1.0.0-rc.5
- require literal keys for explicit interface registrations
- add compile-time regression tests and migration guidance

## Validation

- `pnpm test:types`
- `pnpm test --run`
- `pnpm build`
