### PR TITLE
Release packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,6 +6,7 @@
   },
   "changesets": [
     "quiet-tools-release",
+    "single-interface-key",
     "strict-interface-keys"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-rc.6
+
+### Patch Changes
+
+- d749ee3: Reject interface registration key types that can represent more than one runtime value. This includes unions and open template-literal patterns. Use one fixed string literal as the key type.
+
 ## 1.0.0-rc.5
 
 ### Patch Changes

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@shirudo/kizuna",
-    "version": "1.0.0-rc.5",
+    "version": "1.0.0-rc.6",
     "description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
     "keywords": [
         "Dependency Injection",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shirudo/kizuna",
-	"version": "1.0.0-rc.5",
+	"version": "1.0.0-rc.6",
 	"description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- release `@shirudo/kizuna` as `1.0.0-rc.6`
- document the fixed-literal requirement for interface registration keys
- include the type-safety fix for union and open template-literal keys
