### PR TITLE
Release packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -6,6 +6,7 @@
   },
   "changesets": [
     "quiet-tools-release",
+    "separate-service-provider-token",
     "single-interface-key",
     "strict-interface-keys"
   ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.0-rc.7
+
+### Patch Changes
+
+- bf581a6: Keep the `ServiceProvider` constructor token separate from the string key `"ServiceProvider"`. A user registration with that string key is no longer overwritten by provider self-resolution.
+
 ## 1.0.0-rc.6
 
 ### Patch Changes

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@shirudo/kizuna",
-    "version": "1.0.0-rc.6",
+    "version": "1.0.0-rc.7",
     "description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
     "keywords": [
         "Dependency Injection",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shirudo/kizuna",
-	"version": "1.0.0-rc.6",
+	"version": "1.0.0-rc.7",
 	"description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- version `@shirudo/kizuna` as `1.0.0-rc.7`
- keep the `ServiceProvider` constructor token separate from the same string key
- document explicit provider self-resolution and the collision-free string registration
