### PR TITLE
fix(api): remove unstable constructor resolution

### DIFF
--- a/.changeset/stable-string-resolution.md
+++ b/.changeset/stable-string-resolution.md
@@ -1,0 +1,7 @@
+---
+"@shirudo/kizuna": major
+---
+
+Remove arbitrary constructor tokens from `get()`. Resolve registered services
+through their string keys. `get(ServiceProvider)` remains available as the one
+explicit infrastructure-token lookup.

--- a/.changeset/stable-string-resolution.md
+++ b/.changeset/stable-string-resolution.md
@@ -3,5 +3,6 @@
 ---
 
 Remove arbitrary constructor tokens from `get()`. Resolve registered services
-through their string keys. `get(ServiceProvider)` remains available as the one
-explicit infrastructure-token lookup.
+through their string keys. Use `get(ServiceProviderToken)` for the one explicit
+infrastructure-token lookup. Replace existing `get(ServiceProvider)` calls with
+the new symbol token.

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ The built container interface for service resolution.
 ```typescript
 interface TypeSafeServiceLocator<TRegistry> {
   get<K extends keyof TRegistry>(key: K): TRegistry[K];      // Resolve service
-  get(token: typeof ServiceProvider): ServiceProvider<TRegistry>; // Get current provider
+  get(token: typeof ServiceProviderToken): ServiceProvider<TRegistry>; // Get current provider
   getAll<K extends keyof TRegistry>(key: K): TRegistry[K][]; // Resolve all implementations as array
   startScope(): TypeSafeServiceLocator<TRegistry>;            // Create new scope
   dispose(): void;                                            // Synchronous cleanup
@@ -570,9 +570,9 @@ interface TypeSafeServiceLocator<TRegistry> {
 }
 ```
 
-`ServiceProvider` is also an explicit infrastructure token. Calling
-`container.get(ServiceProvider)` returns the current root or scoped provider.
-This constructor token is separate from the string key `"ServiceProvider"`.
+`ServiceProviderToken` is an explicit infrastructure token. Calling
+`container.get(ServiceProviderToken)` returns the current root or scoped
+provider. This symbol token is separate from the string key `"ServiceProvider"`.
 That string remains available for normal user registrations. Other constructors
 are not resolution keys. Resolve registered services through their string keys.
 

--- a/README.md
+++ b/README.md
@@ -560,7 +560,7 @@ The built container interface for service resolution.
 ```typescript
 interface TypeSafeServiceLocator<TRegistry> {
   get<K extends keyof TRegistry>(key: K): TRegistry[K];      // Resolve service
-  get<T extends new (...args: any[]) => any>(type: T): InstanceType<T>;
+  get(token: typeof ServiceProvider): ServiceProvider<TRegistry>; // Get current provider
   getAll<K extends keyof TRegistry>(key: K): TRegistry[K][]; // Resolve all implementations as array
   startScope(): TypeSafeServiceLocator<TRegistry>;            // Create new scope
   dispose(): void;                                            // Synchronous cleanup
@@ -573,7 +573,8 @@ interface TypeSafeServiceLocator<TRegistry> {
 `ServiceProvider` is also an explicit infrastructure token. Calling
 `container.get(ServiceProvider)` returns the current root or scoped provider.
 This constructor token is separate from the string key `"ServiceProvider"`.
-That string remains available for normal user registrations.
+That string remains available for normal user registrations. Other constructors
+are not resolution keys. Resolve registered services through their string keys.
 
 ### Service Lifecycles
 

--- a/docs/adr/002-dual-service-key-strategy.md
+++ b/docs/adr/002-dual-service-key-strategy.md
@@ -2,7 +2,11 @@
 
 ## Status
 
-Accepted
+Superseded by the string-key resolution model and ADR-008 (2026-08-04).
+
+This document records the previous design. Its constructor-key examples do not
+describe the current public API. Services now use string registry keys, while
+`ServiceProviderToken` is the only non-string resolution token.
 
 ## Context
 

--- a/docs/adr/004-immutable-service-container-design.md
+++ b/docs/adr/004-immutable-service-container-design.md
@@ -269,8 +269,8 @@ builder.addSingleton((r) =>
   r.fromName("Service").useFactory((provider) => {
     const condition = provider.get<Config>("Config").useFeatureX;
     const dep = condition
-      ? provider.get(FeatureXService)
-      : provider.get(DefaultService);
+      ? provider.get('FeatureXService')
+      : provider.get('DefaultService');
     return new Service(dep);
   })
 );

--- a/docs/adr/006-scope-creation-strategy.md
+++ b/docs/adr/006-scope-creation-strategy.md
@@ -51,9 +51,9 @@ const scope1 = parentProvider.startScope();
 const scope2 = parentProvider.startScope();
 
 // Each scope has completely independent scoped services
-const service1 = scope1.get(ScopedService); // Instance A
-const service2 = scope2.get(ScopedService); // Instance B (different)
-const parentService = parentProvider.get(ScopedService); // Instance C (different)
+const service1 = scope1.get('ScopedService'); // Instance A
+const service2 = scope2.get('ScopedService'); // Instance B (different)
+const parentService = parentProvider.get('ScopedService'); // Instance C (different)
 ```
 
 - No shared state between different scopes
@@ -106,7 +106,7 @@ scopedRegistrations["ScopedService"] = new ScopedLifecycle(factory, deps); // Ne
 scope.dispose(); // Disposes only scoped service instances
 
 // Parent container remains unaffected
-parentProvider.get(SingletonService); // Still works
+parentProvider.get('SingletonService'); // Still works
 ```
 
 - Clear ownership model for scoped instances
@@ -257,12 +257,12 @@ const rootProvider = builder.build();
 const scopedProvider = rootProvider.startScope();
 
 // Services behave according to their lifecycle
-const singleton1 = rootProvider.get(SingletonService);
-const singleton2 = scopedProvider.get(SingletonService);
+const singleton1 = rootProvider.get('SingletonService');
+const singleton2 = scopedProvider.get('SingletonService');
 // singleton1 === singleton2 (same instance)
 
-const scoped1 = rootProvider.get(ScopedService);
-const scoped2 = scopedProvider.get(ScopedService);
+const scoped1 = rootProvider.get('ScopedService');
+const scoped2 = scopedProvider.get('ScopedService');
 // scoped1 !== scoped2 (different instances)
 ```
 
@@ -274,8 +274,8 @@ const scope1 = rootProvider.startScope();
 const scope2 = scope1.startScope(); // Nested scope
 
 // Each scope maintains independence
-const service1 = scope1.get(ScopedService);
-const service2 = scope2.get(ScopedService);
+const service1 = scope1.get('ScopedService');
+const service2 = scope2.get('ScopedService');
 // service1 !== service2
 ```
 
@@ -283,13 +283,13 @@ const service2 = scope2.get(ScopedService);
 
 ```typescript
 const scope = rootProvider.startScope();
-const scopedService = scope.get(ScopedService);
+const scopedService = scope.get('ScopedService');
 
 // Clean up scope
 scope.dispose(); // Disposes scoped service instances
 
 // Root provider remains functional
-const rootService = rootProvider.get(SingletonService); // Still works
+const rootService = rootProvider.get('SingletonService'); // Still works
 ```
 
 ## Consequences

--- a/docs/adr/007-fail-fast-error-handling.md
+++ b/docs/adr/007-fail-fast-error-handling.md
@@ -65,7 +65,7 @@ builder.addSingleton(
 );
 
 // vs runtime discovery:
-const service = container.get(InvalidService); // Would fail much later
+const service = container.get('InvalidService'); // Would fail much later
 ```
 
 - Configuration errors discovered during application setup

--- a/docs/adr/008-self-registration-pattern.md
+++ b/docs/adr/008-self-registration-pattern.md
@@ -20,12 +20,12 @@ We have **reversed the original automatic self-registration decision**. The
 service provider is not stored in the normal string-key registry.
 
 The `TypeSafeServiceLocator` is passed directly to factory functions at
-resolution time. Infrastructure code can also call `get(ServiceProvider)` to
-get the current root or scoped provider. This lookup uses constructor identity;
-it is not a hidden service registration.
+resolution time. Infrastructure code can also call `get(ServiceProviderToken)`
+to get the current root or scoped provider. This lookup uses an exported unique
+symbol; it is not a hidden service registration.
 
-The constructor token `ServiceProvider` and the string key
-`"ServiceProvider"` are separate. Users can register the string key without
+The symbol token `ServiceProviderToken` and the string key `"ServiceProvider"`
+are separate. Users can register the string key without
 overwriting provider self-resolution. The provider cannot be injected through a
 string dependency unless the user registers a value under that string. No other
 constructor is a resolution token. Registered services are resolved through
@@ -46,8 +46,8 @@ This change was made to enforce a cleaner dependency injection architecture and 
 4.  **Preserves the Power of Factories**: Factory functions receive the current
     provider directly for complex or conditional service creation.
 
-5.  **Prevents Key Collisions**: Constructor identity cannot overwrite a user
-    registration that happens to use the same text as the class name.
+5.  **Prevents Key Collisions**: Symbol identity cannot overwrite a user
+    registration that happens to use the same text as the token description.
 
 ## Implementation Pattern
 
@@ -97,7 +97,7 @@ const service = container.get('ComplexService');
 ### Explicit Infrastructure Lookup
 
 ```typescript
-import { ContainerBuilder, ServiceProvider } from '@shirudo/kizuna';
+import { ContainerBuilder, ServiceProviderToken } from '@shirudo/kizuna';
 
 class DiagnosticService {}
 
@@ -105,8 +105,8 @@ const container = new ContainerBuilder()
   .registerSingleton('ServiceProvider', DiagnosticService)
   .build();
 
-container.get(ServiceProvider);   // The current provider
-container.get('ServiceProvider'); // DiagnosticService
+container.get(ServiceProviderToken); // The current provider
+container.get('ServiceProvider');    // DiagnosticService
 ```
 
 ## Consequences
@@ -139,5 +139,5 @@ container.get('ServiceProvider'); // DiagnosticService
 *   **Description**: Require the user to explicitly register the provider under
     a string key if they want to inject it.
 *   **Reason for Rejection**: This is verbose and enables hidden service-locator
-    dependencies. Factory arguments and explicit constructor-token lookup cover
+    dependencies. Factory arguments and explicit symbol-token lookup cover
     the intended infrastructure use cases.

--- a/docs/adr/008-self-registration-pattern.md
+++ b/docs/adr/008-self-registration-pattern.md
@@ -27,7 +27,9 @@ it is not a hidden service registration.
 The constructor token `ServiceProvider` and the string key
 `"ServiceProvider"` are separate. Users can register the string key without
 overwriting provider self-resolution. The provider cannot be injected through a
-string dependency unless the user registers a value under that string.
+string dependency unless the user registers a value under that string. No other
+constructor is a resolution token. Registered services are resolved through
+their string keys, so runtime resolution does not depend on `constructor.name`.
 
 ## Rationale
 
@@ -115,7 +117,10 @@ container.get('ServiceProvider'); // DiagnosticService
 *   **Improved Testability**: Services are easier to unit test in isolation.
 *   **Clear Dependencies**: A service's dependencies are made explicit in its constructor.
 *   **Reduced Complexity**: Eliminates hidden provider registrations and keeps
-    constructor-token lookup separate from user keys.
+    the one explicit infrastructure token separate from user keys.
+
+*   **Stable Resolution**: Service lookup does not depend on constructor names,
+    which build tools can change.
 
 ### Negative
 

--- a/src/api/contracts/interfaces.ts
+++ b/src/api/contracts/interfaces.ts
@@ -1,4 +1,5 @@
 import type { ServiceWrapper } from '../../core/services/service-wrapper';
+import type { ServiceProvider } from '../service-provider';
 
 /**
  * Container interface defines the contract for service lifecycle management.
@@ -86,15 +87,15 @@ export interface ServiceBuilder {
  * ServiceLocator interface defines the contract for service resolution and container management.
  * 
  * This interface is implemented by ServiceProvider and provides the main API for resolving
- * services from the dependency injection container. It supports service resolution by both
- * string keys and constructor types, scope management, and resource cleanup.
+ * services from the dependency injection container. It supports service resolution by
+ * string keys, scope management, and resource cleanup.
  * 
  * @example
  * ```typescript
  * const serviceLocator: ServiceLocator = containerBuilder.build();
  * 
  * // Resolve services
- * const userService = serviceLocator.get(UserService);
+ * const userService = serviceLocator.get<UserService>('UserService');
  * const apiClient = serviceLocator.get<IApiClient>('ApiClient');
  * 
  * // Manage scopes
@@ -114,14 +115,10 @@ export interface ServiceLocator {
     get<T>(objToImplement: string): T;
     
     /**
-     * Resolves a service by constructor type.
-     * 
-     * @template T - The constructor type of the service
-     * @param objToImplement - The constructor function of the service
-     * @returns An instance of the requested service
-     * @throws {Error} If no service is registered for the given type
+     * Returns the current provider through its explicit infrastructure token.
+     * Other constructor tokens are not service keys.
      */
-    get<T extends new (...args: any) => any>(objToImplement: T): InstanceType<T>;
+    get(token: typeof ServiceProvider): ServiceProvider<Record<string, any>>;
 
     /**
      * Creates a new scope for isolated service resolution.
@@ -184,13 +181,10 @@ export interface TypeSafeServiceLocator<TRegistry extends Record<string, any>> {
     get<K extends keyof TRegistry>(key: K): TRegistry[K];
     
     /**
-     * Resolves a service by constructor type.
-     *
-     * @template T - The constructor type of the service
-     * @param objToImplement - The constructor function of the service
-     * @returns An instance of the requested service
+     * Returns the current provider through its explicit infrastructure token.
+     * Other constructor tokens are not service keys.
      */
-    get<T extends new (...args: any) => any>(objToImplement: T): InstanceType<T>;
+    get(token: typeof ServiceProvider): ServiceProvider<TRegistry>;
 
     /**
      * Resolves all implementations registered under a key as an array.

--- a/src/api/contracts/interfaces.ts
+++ b/src/api/contracts/interfaces.ts
@@ -1,5 +1,5 @@
 import type { ServiceWrapper } from '../../core/services/service-wrapper';
-import type { ServiceProvider } from '../service-provider';
+import type { ServiceProvider, ServiceProviderToken } from '../service-provider';
 
 /**
  * Container interface defines the contract for service lifecycle management.
@@ -116,9 +116,9 @@ export interface ServiceLocator {
     
     /**
      * Returns the current provider through its explicit infrastructure token.
-     * Other constructor tokens are not service keys.
+     * Constructor values are not service keys.
      */
-    get(token: typeof ServiceProvider): ServiceProvider<Record<string, any>>;
+    get(token: typeof ServiceProviderToken): ServiceProvider<Record<string, any>>;
 
     /**
      * Creates a new scope for isolated service resolution.
@@ -182,9 +182,9 @@ export interface TypeSafeServiceLocator<TRegistry extends Record<string, any>> {
     
     /**
      * Returns the current provider through its explicit infrastructure token.
-     * Other constructor tokens are not service keys.
+     * Constructor values are not service keys.
      */
-    get(token: typeof ServiceProvider): ServiceProvider<TRegistry>;
+    get(token: typeof ServiceProviderToken): ServiceProvider<TRegistry>;
 
     /**
      * Resolves all implementations registered under a key as an array.

--- a/src/api/contracts/types.ts
+++ b/src/api/contracts/types.ts
@@ -24,14 +24,14 @@ import type { ServiceLocator } from './interfaces';
  * 
  * // Factory with dependencies
  * const userServiceFactory: Factory<UserService> = (provider) => {
- *   const db = provider.get(DatabaseService);
+ *   const db = provider.get<DatabaseService>('DatabaseService');
  *   const logger = provider.get<ILogger>('Logger');
  *   return new UserService(db, logger);
  * };
  * 
  * // Conditional factory
  * const apiClientFactory: Factory<ApiClient> = (provider) => {
- *   const config = provider.get(AppConfig);
+ *   const config = provider.get<AppConfig>('AppConfig');
  *   return config.isDevelopment 
  *     ? new MockApiClient() 
  *     : new ApiClient(config.apiUrl);
@@ -61,7 +61,7 @@ export type Factory<T> = (serviceProvider: ServiceLocator) => T;
  * 
  * // Usage in service resolution
  * const logger = provider.get<ILogger>('Logger');        // string key
- * const userService = provider.get(UserService);         // constructor key
+ * const userService = provider.get<UserService>('UserService'); // string resolution key
  * ```
  * 
  * @example
@@ -72,7 +72,9 @@ export type Factory<T> = (serviceProvider: ServiceLocator) => T;
  * }
  * 
  * registerService('Logger', () => new ConsoleLogger());
- * registerService(UserService, (provider) => new UserService(provider.get(DatabaseService)));
+ * registerService(UserService, (provider) =>
+ *   new UserService(provider.get<DatabaseService>('DatabaseService'))
+ * );
  * ```
  */
 export type ServiceKey<T = any> = string | (new (...args: any[]) => T);
@@ -125,7 +127,7 @@ export interface TypeSafeRegistrar<T> {
      * @param dependencies - Optional dependency keys
      */
     useType<TCtor extends new (...args: any[]) => T>(
-        constructor: TCtor,
+        constructorType: TCtor,
         ...dependencies: string[]
     ): void;
 

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -38,7 +38,11 @@
 export { ContainerBuilder } from "./container-builder";
 
 // Service provider (type-safe by design)
-export { CircularDependencyError, ServiceProvider } from "./service-provider";
+export {
+    CircularDependencyError,
+    ServiceProvider,
+    ServiceProviderToken,
+} from "./service-provider";
 
 // Contracts and interfaces
 export {

--- a/src/api/service-provider.ts
+++ b/src/api/service-provider.ts
@@ -1,7 +1,7 @@
 import { CircularDependencyError } from "../core/errors";
 import type { ServiceWrapper } from "../core/services/service-wrapper";
 import type { TypeSafeServiceLocator } from "./contracts/interfaces";
-import type { ServiceKey, ServiceRegistry } from "./contracts/types";
+import type { ServiceRegistry } from "./contracts/types";
 
 export { CircularDependencyError } from "../core/errors";
 
@@ -43,15 +43,19 @@ export class ServiceProvider<TRegistry extends ServiceRegistry>
      * Type-safe service resolution with autocompletion and type inference.
      */
     get<K extends keyof TRegistry>(key: K): TRegistry[K];
-    get<T extends new (...args: any) => any>(objToImplement: T): InstanceType<T>;
-    get(keyOrType: any): any {
+    get(token: typeof ServiceProvider): ServiceProvider<TRegistry>;
+    get(keyOrType: keyof TRegistry | typeof ServiceProvider): unknown {
         this.ensureNotDisposed();
 
         if (keyOrType === ServiceProvider) {
             return this;
         }
 
-        const typeName = this.getTypeName(keyOrType as ServiceKey);
+        if (typeof keyOrType !== "string") {
+            throw new TypeError("Service keys must be strings or ServiceProvider");
+        }
+
+        const typeName = keyOrType;
 
         // Check multi-registrations first
         const multiResolvers = this.multiRegistrations[typeName];
@@ -259,9 +263,5 @@ export class ServiceProvider<TRegistry extends ServiceRegistry>
         } finally {
             this._resolutionStack.pop();
         }
-    }
-
-    private getTypeName<T>(keyOrType: ServiceKey<T>): string {
-        return typeof keyOrType === "string" ? keyOrType : keyOrType.name;
     }
 }

--- a/src/api/service-provider.ts
+++ b/src/api/service-provider.ts
@@ -5,6 +5,9 @@ import type { ServiceRegistry } from "./contracts/types";
 
 export { CircularDependencyError } from "../core/errors";
 
+/** Stable identity token for resolving the current service provider. */
+export const ServiceProviderToken: unique symbol = Symbol("ServiceProvider");
+
 /**
  * ServiceProvider that provides compile-time safety and IDE autocompletion.
  *
@@ -43,16 +46,16 @@ export class ServiceProvider<TRegistry extends ServiceRegistry>
      * Type-safe service resolution with autocompletion and type inference.
      */
     get<K extends keyof TRegistry>(key: K): TRegistry[K];
-    get(token: typeof ServiceProvider): ServiceProvider<TRegistry>;
-    get(keyOrType: keyof TRegistry | typeof ServiceProvider): unknown {
+    get(token: typeof ServiceProviderToken): ServiceProvider<TRegistry>;
+    get(keyOrType: keyof TRegistry | typeof ServiceProviderToken): unknown {
         this.ensureNotDisposed();
 
-        if (keyOrType === ServiceProvider) {
+        if (keyOrType === ServiceProviderToken) {
             return this;
         }
 
         if (typeof keyOrType !== "string") {
-            throw new TypeError("Service keys must be strings or ServiceProvider");
+            throw new TypeError("Service keys must be strings or ServiceProviderToken");
         }
 
         const typeName = keyOrType;

--- a/src/core/scopes/scoped.ts
+++ b/src/core/scopes/scoped.ts
@@ -32,13 +32,13 @@ import { invokeAsyncDispose, invokeSyncDispose } from '../services/async-dispose
  * 
  * // Within the same scope - same instance
  * const scope1 = container.startScope();
- * const ctx1a = scope1.get(UserContext);
- * const ctx1b = scope1.get(UserContext);
+ * const ctx1a = scope1.get('UserContext');
+ * const ctx1b = scope1.get('UserContext');
  * console.log(ctx1a === ctx1b); // true
  * 
  * // Different scope - different instance
  * const scope2 = container.startScope();
- * const ctx2 = scope2.get(UserContext);
+ * const ctx2 = scope2.get('UserContext');
  * console.log(ctx1a === ctx2); // false
  * 
  * // Clean up when done

--- a/src/core/scopes/singleton.ts
+++ b/src/core/scopes/singleton.ts
@@ -28,15 +28,15 @@ import { invokeAsyncDispose, invokeSyncDispose } from '../services/async-dispose
  * builder.registerSingleton('DatabaseService', DatabaseService);
  *
  * // All requests return the same instance
- * const db1 = container.get(DatabaseService);
- * const db2 = container.get(DatabaseService);
+ * const db1 = container.get('DatabaseService');
+ * const db2 = container.get('DatabaseService');
  * console.log(db1 === db2); // true
  *
  * // Same instance across different scopes
  * const scope1 = container.startScope();
  * const scope2 = container.startScope();
- * const db3 = scope1.get(DatabaseService);
- * const db4 = scope2.get(DatabaseService);
+ * const db3 = scope1.get('DatabaseService');
+ * const db4 = scope2.get('DatabaseService');
  * console.log(db1 === db3 && db3 === db4); // true
  * ```
  *

--- a/src/core/scopes/transient.ts
+++ b/src/core/scopes/transient.ts
@@ -29,14 +29,14 @@ import { CircularDependencyError } from '../errors';
  * builder.registerTransient('Logger', Logger);
  * 
  * // Every request creates a new instance
- * const logger1 = container.get(Logger);
- * const logger2 = container.get(Logger);
+ * const logger1 = container.get('Logger');
+ * const logger2 = container.get('Logger');
  * console.log(logger1 === logger2); // false - different instances
  * 
  * // Even within the same scope - still different instances
  * const scope = container.startScope();
- * const logger3 = scope.get(Logger);
- * const logger4 = scope.get(Logger);
+ * const logger3 = scope.get('Logger');
+ * const logger4 = scope.get('Logger');
  * console.log(logger3 === logger4); // false - always new instances
  * 
  * // Each instance is independent

--- a/tests/self-resolver.test-d.ts
+++ b/tests/self-resolver.test-d.ts
@@ -1,8 +1,15 @@
 import { expectTypeOf, test } from "vitest";
 import { ContainerBuilder } from "../src/api/container-builder";
-import { ServiceProvider } from "../src/api/service-provider";
+import {
+	ServiceProvider,
+	ServiceProviderToken,
+} from "../src/api/service-provider";
 
 class DiagnosticService {}
+
+class DerivedProvider<
+	TRegistry extends Record<string, unknown>,
+> extends ServiceProvider<TRegistry> {}
 
 test("self-resolution is available without weakening the public types", () => {
 	const provider = new ContainerBuilder()
@@ -13,10 +20,13 @@ test("self-resolution is available without weakening the public types", () => {
 		provider.get("ServiceProvider"),
 	).toEqualTypeOf<DiagnosticService>();
 
-	const currentProvider = provider.get(ServiceProvider);
+	const currentProvider = provider.get(ServiceProviderToken);
 	expectTypeOf(currentProvider).not.toBeAny();
 	expectTypeOf(currentProvider).toMatchTypeOf<{ startScope(): unknown }>();
 
 	// @ts-expect-error Registered services must be resolved through their registry key.
 	provider.get(DiagnosticService);
+
+	// @ts-expect-error A provider subclass is not the explicit identity token.
+	provider.get(DerivedProvider);
 });

--- a/tests/self-resolver.test-d.ts
+++ b/tests/self-resolver.test-d.ts
@@ -16,4 +16,7 @@ test("self-resolution is available without weakening the public types", () => {
 	const currentProvider = provider.get(ServiceProvider);
 	expectTypeOf(currentProvider).not.toBeAny();
 	expectTypeOf(currentProvider).toMatchTypeOf<{ startScope(): unknown }>();
+
+	// @ts-expect-error Registered services must be resolved through their registry key.
+	provider.get(DiagnosticService);
 });

--- a/tests/self-resolver.test.ts
+++ b/tests/self-resolver.test.ts
@@ -50,6 +50,19 @@ describe("ServiceProvider self-resolution", () => {
 		expect(container.get(ServiceProvider)).toBe(container);
 	});
 
+	it("rejects constructor tokens other than ServiceProvider at runtime", () => {
+		const container = new ContainerBuilder()
+			.registerSingleton("dummy", Dummy)
+			.build();
+		const untypedContainer = container as unknown as {
+			get(token: unknown): unknown;
+		};
+
+		expect(() => untypedContainer.get(Dummy)).toThrow(
+			"Service keys must be strings or ServiceProvider",
+		);
+	});
+
 	it("resolves the scope provider (not the parent) inside a scope", () => {
 		const container = new ContainerBuilder()
 			.registerSingleton("dummy", Dummy)

--- a/tests/self-resolver.test.ts
+++ b/tests/self-resolver.test.ts
@@ -1,18 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { ContainerBuilder } from "../src/api/container-builder";
-import { ServiceProvider } from "../src/api/service-provider";
+import { ServiceProviderToken } from "../src/api/service-provider";
 
 class Dummy {}
 class OtherDummy {}
 
 describe("ServiceProvider self-resolution", () => {
-	it("keeps the constructor token separate from the same string key", () => {
+	it("keeps the identity token separate from the same string key", () => {
 		const container = new ContainerBuilder()
 			.registerSingleton("ServiceProvider", Dummy)
 			.build();
 
 		expect(container.get("ServiceProvider")).toBeInstanceOf(Dummy);
-		expect(container.get(ServiceProvider)).toBe(container);
+		expect(container.get(ServiceProviderToken)).toBe(container);
 	});
 
 	it("keeps the string key available in child scopes", () => {
@@ -25,10 +25,10 @@ describe("ServiceProvider self-resolution", () => {
 
 		expect(scope.get("ServiceProvider")).toBeInstanceOf(Dummy);
 		expect(scope.get("ServiceProvider")).not.toBe(rootService);
-		expect(scope.get(ServiceProvider)).toBe(scope);
+		expect(scope.get(ServiceProviderToken)).toBe(scope);
 	});
 
-	it("keeps multi-registrations separate from the constructor token", () => {
+	it("keeps multi-registrations separate from the identity token", () => {
 		const container = new ContainerBuilder()
 			.addSingleton("ServiceProvider", Dummy)
 			.addSingleton("ServiceProvider", OtherDummy)
@@ -39,7 +39,7 @@ describe("ServiceProvider self-resolution", () => {
 		expect(services).toHaveLength(2);
 		expect(services[0]).toBeInstanceOf(Dummy);
 		expect(services[1]).toBeInstanceOf(OtherDummy);
-		expect(container.get(ServiceProvider)).toBe(container);
+		expect(container.get(ServiceProviderToken)).toBe(container);
 	});
 
 	it("resolves itself under the ServiceProvider key at the root", () => {
@@ -47,10 +47,10 @@ describe("ServiceProvider self-resolution", () => {
 			.registerSingleton("dummy", Dummy)
 			.build();
 
-		expect(container.get(ServiceProvider)).toBe(container);
+		expect(container.get(ServiceProviderToken)).toBe(container);
 	});
 
-	it("rejects constructor tokens other than ServiceProvider at runtime", () => {
+	it("rejects class constructors at runtime", () => {
 		const container = new ContainerBuilder()
 			.registerSingleton("dummy", Dummy)
 			.build();
@@ -59,7 +59,7 @@ describe("ServiceProvider self-resolution", () => {
 		};
 
 		expect(() => untypedContainer.get(Dummy)).toThrow(
-			"Service keys must be strings or ServiceProvider",
+			"Service keys must be strings or ServiceProviderToken",
 		);
 	});
 
@@ -69,8 +69,8 @@ describe("ServiceProvider self-resolution", () => {
 			.build();
 
 		const scope = container.startScope();
-		expect(scope.get(ServiceProvider)).toBe(scope);
-		expect(scope.get(ServiceProvider)).not.toBe(container);
+		expect(scope.get(ServiceProviderToken)).toBe(scope);
+		expect(scope.get(ServiceProviderToken)).not.toBe(container);
 	});
 
 	it("keeps the parent usable after a scope holding a self-reference is disposed", () => {
@@ -79,11 +79,11 @@ describe("ServiceProvider self-resolution", () => {
 			.build();
 
 		const scope = container.startScope();
-		scope.get(ServiceProvider);
+		scope.get(ServiceProviderToken);
 		scope.dispose();
 
 		expect(container.get("dummy")).toBeInstanceOf(Dummy);
-		expect(container.get(ServiceProvider)).toBe(container);
+		expect(container.get(ServiceProviderToken)).toBe(container);
 	});
 
 	it("dispose remains idempotent with the self-resolver present", () => {
@@ -91,7 +91,7 @@ describe("ServiceProvider self-resolution", () => {
 			.registerSingleton("dummy", Dummy)
 			.build();
 
-		container.get(ServiceProvider);
+		container.get(ServiceProviderToken);
 		expect(() => {
 			container.dispose();
 			container.dispose();

--- a/tests/singleton-dispose.test.ts
+++ b/tests/singleton-dispose.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { ContainerBuilder } from '../src/api/container-builder';
-import { ServiceProvider } from '../src/api/service-provider';
+import { ServiceProviderToken } from '../src/api/service-provider';
 
 class DisposableService {
     disposed = false;
@@ -138,22 +138,22 @@ describe('Post-dispose behavior', () => {
         expect(scope.get('scoped')).toBe(scopedBefore); // Same scoped instance
     });
 
-    it('should allow self-registration via get(ServiceProvider)', () => {
+    it('should resolve the root provider through its identity token', () => {
         const container = new ContainerBuilder()
             .registerSingleton('service', NonDisposableService)
             .build();
 
-        const self = container.get(ServiceProvider);
+        const self = container.get(ServiceProviderToken);
         expect(self).toBe(container);
     });
 
-    it('should allow self-registration via get(ServiceProvider) in child scope', () => {
+    it('should resolve the scoped provider through its identity token', () => {
         const container = new ContainerBuilder()
             .registerSingleton('service', NonDisposableService)
             .build();
 
         const scope = container.startScope();
-        const self = scope.get(ServiceProvider);
+        const self = scope.get(ServiceProviderToken);
         expect(self).toBe(scope);
     });
 


### PR DESCRIPTION
## Summary

- restrict `get()` to registered string keys and the opaque `ServiceProviderToken` symbol
- remove the `constructor.name` lookup path and reject constructor values at compile time and runtime
- mark the obsolete dual-key ADR as superseded and update accepted ADR examples
- document the breaking migration and add an RC changeset

## Verification

- 244 runtime tests pass
- public type tests reject arbitrary constructors and generic `ServiceProvider` subclasses
- ESM/CJS builds, declaration generation, and root-export smoke tests pass
- Biome lint passes for all changed TypeScript files

Tracks `kizuna-5da.1.4`.
