### PR TITLE
Release packages (rc)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -8,6 +8,7 @@
     "quiet-tools-release",
     "separate-service-provider-token",
     "single-interface-key",
+    "stable-string-resolution",
     "strict-interface-keys"
   ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 1.0.0-rc.8
+
+### Major Changes
+
+- 73c153e: Remove arbitrary constructor tokens from `get()`. Resolve registered services
+  through their string keys. Use `get(ServiceProviderToken)` for the one explicit
+  infrastructure-token lookup. Replace existing `get(ServiceProvider)` calls with
+  the new symbol token.
+
 ## 1.0.0-rc.7
 
 ### Patch Changes

--- a/jsr.json
+++ b/jsr.json
@@ -1,6 +1,6 @@
 {
     "name": "@shirudo/kizuna",
-    "version": "1.0.0-rc.7",
+    "version": "1.0.0-rc.8",
     "description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
     "keywords": [
         "Dependency Injection",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@shirudo/kizuna",
-	"version": "1.0.0-rc.7",
+	"version": "1.0.0-rc.8",
 	"description": "A powerful and flexible dependency injection library for TypeScript and JavaScript.",
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## Summary

- version `@shirudo/kizuna` as `1.0.0-rc.8`
- replace arbitrary constructor resolution with registered string keys
- expose `ServiceProviderToken` as the exact provider identity token
- document the breaking migration and superseded dual-key design
