### PR TITLE
fix(release): publish packages with npm OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,10 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   version:
-    name: Create version pull request
+    name: Version or publish package
+    if: github.ref == 'refs/heads/main'
+    environment:
+      name: npm
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,11 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write
+  id-token: write
   pull-requests: write
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
@@ -25,17 +27,26 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 20.19.x
-          cache: pnpm
+          node-version: 24.x
+          package-manager-cache: false
+          registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create or update version pull request
+      - name: Create version pull request or publish to npm
+        id: changesets
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
+          publish: pnpm release
           version: pnpm version-packages
           title: Release packages
           commit: "chore(release): version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify npm release state
+        run: node scripts/verify-release.mjs
+        env:
+          PUBLISHED: ${{ steps.changesets.outputs.published }}
+          PUBLISHED_PACKAGES: ${{ steps.changesets.outputs.publishedPackages }}

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -3,6 +3,43 @@
 Kizuna uses Changesets for Semantic Versioning and changelog entries.
 The current release channel is `rc`.
 
+## Publication targets
+
+The automated publication target is npm only.
+
+- Release candidate versions such as `1.0.0-rc.8` use the npm `rc` dist-tag.
+- Stable versions such as `1.0.0` use the npm `latest` dist-tag.
+- JSR is not an automated publication target. `jsr.json` keeps the same version
+  as `package.json`, but the workflow does not publish or check a remote JSR
+  package.
+
+After the release step, the workflow compares these values:
+
+- the versions in `package.json` and `jsr.json`;
+- the exact version on npm;
+- the expected npm dist-tag;
+- the publication result from the Changesets action.
+
+The workflow fails if these values do not agree.
+
+## Configure npm trusted publishing
+
+An npm package owner must configure this once in the package settings for
+`@shirudo/kizuna`:
+
+- Publisher: GitHub Actions
+- Organization or user: `shi-rudo`
+- Repository: `kizuna`
+- Workflow filename: `release.yml`
+- Allowed action: `npm publish`
+
+Do not add an `NPM_TOKEN` write secret. The workflow uses a short-lived GitHub
+OIDC identity. It runs on Node.js 24 and uses npm CLI to publish. npm creates
+provenance for this public package and repository.
+
+If the npm settings do not match, publication fails with an authentication or
+registry error. npm checks this configuration only during publication.
+
 ## Add a package change
 
 Run this command before you open a pull request:
@@ -20,8 +57,8 @@ Select one bump type:
 Write a short summary for package users. Changesets adds this summary to
 `CHANGELOG.md` during version preparation.
 
-A documentation-only or test-only change does not need a changeset when it
-does not affect package users.
+A documentation-only, test-only, or release-infrastructure change does not need
+a changeset when it does not affect package users.
 
 ## Prepare a version
 
@@ -46,14 +83,44 @@ Review and merge that pull request when the release is ready.
 
 ## Publish to npm
 
-The GitHub workflow does not publish packages. A maintainer publishes the
-reviewed version with this command:
+When no unconsumed changeset remains, the release workflow builds the package
+and publishes an npm version that does not exist yet. It uses `rc` or `latest`
+as described above. A missing trusted-publisher configuration, an npm error, or
+a failed registry check makes the workflow fail.
+
+The `pnpm release` command is for the trusted GitHub workflow. It requests npm
+provenance and is not the local emergency command.
+
+## Emergency publication
+
+First, rerun the `Release` workflow from the GitHub Actions page. The
+`workflow_dispatch` trigger uses the same OIDC identity, provenance, checks,
+and dist-tag rules as the normal run.
+
+Use a local publication only when GitHub Actions is unavailable. This path
+requires a maintainer npm login with two-factor authentication. It does not
+produce GitHub Actions provenance.
+
+1. Check out the exact release commit. Confirm that the worktree is clean.
+2. Confirm that the version is not already on npm.
+3. Install dependencies and build the package.
+4. Publish with the correct dist-tag.
+5. Check the version and all dist-tags.
+
+For a release candidate, run:
 
 ```bash
-pnpm release
+release_version=1.0.0-rc.8
+npm view "@shirudo/kizuna@$release_version" version
+pnpm install --frozen-lockfile
+pnpm build
+npm publish --access public --tag rc
+npm view "@shirudo/kizuna@$release_version" version
+npm view @shirudo/kizuna dist-tags
 ```
 
-This command builds the package before Changesets publishes it to npm.
+For a stable version, replace `--tag rc` with `--tag latest`. Never publish a
+different version from the one in `package.json` and `jsr.json`.
 
 ## Finish the release candidate phase
 

--- a/docs/releases.md
+++ b/docs/releases.md
@@ -31,11 +31,16 @@ An npm package owner must configure this once in the package settings for
 - Organization or user: `shi-rudo`
 - Repository: `kizuna`
 - Workflow filename: `release.yml`
+- Environment: `npm`
 - Allowed action: `npm publish`
 
 Do not add an `NPM_TOKEN` write secret. The workflow uses a short-lived GitHub
 OIDC identity. It runs on Node.js 24 and uses npm CLI to publish. npm creates
 provenance for this public package and repository.
+
+The GitHub Environment named `npm` allows only the `main` branch. The npm
+Trusted Publisher requires the same environment name. A workflow from another
+branch therefore cannot obtain the accepted publishing identity.
 
 If the npm settings do not match, publication fails with an authentication or
 registry error. npm checks this configuration only during publication.

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"coverage": "vitest run --coverage",
 		"sync-version": "node scripts/sync-version.mjs",
 		"version-packages": "changeset version && pnpm sync-version",
-		"release": "pnpm build && changeset publish"
+		"release": "pnpm build && node scripts/publish-package.mjs"
 	},
 	"author": "shirudo",
 	"license": "MIT",

--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -1,0 +1,118 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import { getTargetDistTag } from "./release-state.mjs";
+
+const executeFile = promisify(execFile);
+
+export const publishPackage = async ({
+	packageName,
+	packageVersion,
+	isPublished,
+	publish,
+}) => {
+	const distTag = getTargetDistTag(packageVersion);
+
+	if (await isPublished()) {
+		return {
+			published: false,
+			distTag,
+			packageName,
+			packageVersion,
+		};
+	}
+
+	await publish(distTag);
+
+	return {
+		published: true,
+		distTag,
+		packageName,
+		packageVersion,
+	};
+};
+
+const errorOutput = (error) =>
+	[error?.message, error?.stdout, error?.stderr]
+		.filter(Boolean)
+		.map(String)
+		.join("\n");
+
+export const runPublishCommand = async ({
+	root = process.cwd(),
+	execute = executeFile,
+	log = console.log,
+} = {}) => {
+	const packageJson = JSON.parse(
+		await readFile(resolve(root, "package.json"), "utf8"),
+	);
+	const { name: packageName, version: packageVersion } = packageJson;
+
+	if (typeof packageName !== "string" || typeof packageVersion !== "string") {
+		throw new Error("package.json must contain a package name and version.");
+	}
+
+	const selector = `${packageName}@${packageVersion}`;
+	const result = await publishPackage({
+		packageName,
+		packageVersion,
+		isPublished: async () => {
+			try {
+				const { stdout } = await execute(
+					"npm",
+					["view", selector, "version", "--json"],
+					{ cwd: root },
+				);
+
+				return JSON.parse(stdout) === packageVersion;
+			} catch (error) {
+				if (/\bE404\b/.test(errorOutput(error))) {
+					return false;
+				}
+
+				throw new Error(`Could not read ${selector} from npm.`, {
+					cause: error,
+				});
+			}
+		},
+		publish: async (distTag) => {
+			await execute(
+				"npm",
+				[
+					"publish",
+					"--access",
+					"public",
+					"--tag",
+					distTag,
+					"--provenance",
+					"--json",
+				],
+				{ cwd: root },
+			);
+		},
+	});
+
+	if (result.published) {
+		log(`New tag: ${selector}`);
+	} else {
+		log(`${selector} is already published.`);
+	}
+
+	return result;
+};
+
+const isMainModule =
+	process.argv[1] !== undefined &&
+	import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
+	try {
+		await runPublishCommand();
+	} catch (error) {
+		console.error(error);
+		process.exitCode = 1;
+	}
+}

--- a/scripts/release-state.mjs
+++ b/scripts/release-state.mjs
@@ -1,0 +1,73 @@
+const stableVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const releaseCandidateVersionPattern =
+	/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)-rc\.(0|[1-9]\d*)$/;
+
+export const getTargetDistTag = (version) => {
+	if (releaseCandidateVersionPattern.test(version)) {
+		return "rc";
+	}
+
+	if (stableVersionPattern.test(version)) {
+		return "latest";
+	}
+
+	if (version.includes("-")) {
+		throw new Error(`Unsupported prerelease version: ${version}`);
+	}
+
+	throw new Error(`Invalid Semantic Version: ${version}`);
+};
+
+export const assertReleaseState = ({
+	packageName,
+	packageVersion,
+	jsrVersion,
+	npmVersion,
+	distTags,
+	published,
+	publishedPackages,
+}) => {
+	const targetDistTag = getTargetDistTag(packageVersion);
+	const errors = [];
+
+	if (jsrVersion !== packageVersion) {
+		errors.push(
+			`jsr.json version ${jsrVersion} does not match package.json version ${packageVersion}.`,
+		);
+	}
+
+	if (npmVersion !== packageVersion) {
+		errors.push(
+			`npm version ${npmVersion} does not match package.json version ${packageVersion}.`,
+		);
+	}
+
+	if (distTags?.[targetDistTag] !== packageVersion) {
+		errors.push(
+			`npm dist-tag ${targetDistTag} points to ${distTags?.[targetDistTag] ?? "nothing"}, not ${packageVersion}.`,
+		);
+	}
+
+	const outputContainsRelease = publishedPackages.some(
+		(release) =>
+			release.name === packageName && release.version === packageVersion,
+	);
+
+	if (published && !outputContainsRelease) {
+		errors.push(
+			`workflow output reports a publication but does not contain ${packageName}@${packageVersion}.`,
+		);
+	}
+
+	if (!published && publishedPackages.length > 0) {
+		errors.push(
+			"workflow output reports no publication but contains published packages.",
+		);
+	}
+
+	if (errors.length > 0) {
+		throw new Error(`Release verification failed:\n- ${errors.join("\n- ")}`);
+	}
+
+	return { targetDistTag };
+};

--- a/scripts/verify-release.mjs
+++ b/scripts/verify-release.mjs
@@ -1,0 +1,103 @@
+import { execFile } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+
+import { assertReleaseState } from "./release-state.mjs";
+
+const executeFile = promisify(execFile);
+const wait = (milliseconds) =>
+	new Promise((resolveWait) => setTimeout(resolveWait, milliseconds));
+
+const readJson = async (path) => JSON.parse(await readFile(path, "utf8"));
+
+export const runVerifyCommand = async ({
+	root = process.cwd(),
+	published = process.env.PUBLISHED ?? "false",
+	publishedPackages = process.env.PUBLISHED_PACKAGES ?? "[]",
+	execute = executeFile,
+	log = console.log,
+	waitForRetry = wait,
+	maxAttempts = 6,
+} = {}) => {
+	const [packageJson, jsrJson] = await Promise.all([
+		readJson(resolve(root, "package.json")),
+		readJson(resolve(root, "jsr.json")),
+	]);
+	const packageName = packageJson.name;
+	const packageVersion = packageJson.version;
+	const workflowPublished = published === "true";
+	const workflowPackages = JSON.parse(publishedPackages.trim() || "[]");
+
+	if (
+		typeof packageName !== "string" ||
+		typeof packageVersion !== "string" ||
+		typeof jsrJson.version !== "string"
+	) {
+		throw new Error("package.json and jsr.json must contain release metadata.");
+	}
+
+	if (!Array.isArray(workflowPackages)) {
+		throw new Error("PUBLISHED_PACKAGES must contain a JSON array.");
+	}
+
+	const attempts = workflowPublished ? maxAttempts : 1;
+	let lastError;
+
+	for (let attempt = 1; attempt <= attempts; attempt += 1) {
+		try {
+			const [{ stdout: versionOutput }, { stdout: distTagsOutput }] =
+				await Promise.all([
+					execute(
+						"npm",
+						["view", `${packageName}@${packageVersion}`, "version", "--json"],
+						{ cwd: root },
+					),
+					execute("npm", ["view", packageName, "dist-tags", "--json"], {
+						cwd: root,
+					}),
+				]);
+			const npmVersion = JSON.parse(versionOutput);
+			const distTags = JSON.parse(distTagsOutput);
+			const { targetDistTag } = assertReleaseState({
+				packageName,
+				packageVersion,
+				jsrVersion: jsrJson.version,
+				npmVersion,
+				distTags,
+				published: workflowPublished,
+				publishedPackages: workflowPackages,
+			});
+
+			log(
+				`Verified ${packageName}@${packageVersion} on npm with dist-tag ${targetDistTag}.`,
+			);
+			return;
+		} catch (error) {
+			lastError = error;
+
+			if (attempt < attempts) {
+				await waitForRetry(5_000);
+			}
+		}
+	}
+
+	throw new Error(
+		`Could not verify ${packageName}@${packageVersion} on npm after ${attempts} attempt${attempts === 1 ? "" : "s"}.`,
+		{ cause: lastError },
+	);
+};
+
+const isMainModule =
+	process.argv[1] !== undefined &&
+	import.meta.url === pathToFileURL(process.argv[1]).href;
+
+if (isMainModule) {
+	try {
+		await runVerifyCommand();
+	} catch (error) {
+		console.error(error);
+		process.exitCode = 1;
+	}
+}

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -74,7 +74,7 @@ describe("Release process", () => {
 			changeset: "changeset",
 			"sync-version": "node scripts/sync-version.mjs",
 			"version-packages": "changeset version && pnpm sync-version",
-			release: "pnpm build && changeset publish",
+			release: "pnpm build && node scripts/publish-package.mjs",
 		});
 	});
 
@@ -106,11 +106,35 @@ describe("Release process", () => {
 		}
 	});
 
-	it("creates version pull requests without automatic publishing", () => {
+	it("creates version pull requests and publishes releases with npm OIDC", () => {
 		const workflow = readText("../.github/workflows/release.yml");
 
+		expect(workflow).toContain("workflow_dispatch:");
 		expect(workflow).toContain("uses: changesets/action@");
 		expect(workflow).toContain("version: pnpm version-packages");
-		expect(workflow).not.toMatch(/^\s+publish:/m);
+		expect(workflow).toContain("publish: pnpm release");
+		expect(workflow).toContain("id-token: write");
+		expect(workflow).toContain("run: node scripts/verify-release.mjs");
+		expect(workflow).toContain(
+			"PUBLISHED: $" + "{{ steps.changesets.outputs.published }}",
+		);
+		expect(workflow).toContain(
+			"PUBLISHED_PACKAGES: $" +
+				"{{ steps.changesets.outputs.publishedPackages }}",
+		);
+	});
+
+	it("documents publication targets, npm setup, and emergency recovery", () => {
+		const guide = readText("../docs/releases.md");
+
+		expect(guide).toContain("The automated publication target is npm only.");
+		expect(guide).toContain("JSR is not an automated publication target");
+		expect(guide).toContain("Workflow filename: `release.yml`");
+		expect(guide).toContain("Allowed action: `npm publish`");
+		expect(guide).toContain("## Emergency publication");
+		expect(guide).toContain(
+			'npm view "@shirudo/kizuna@$release_version" version',
+		);
+		expect(guide).toContain("npm view @shirudo/kizuna dist-tags");
 	});
 });

--- a/tests/release-process.test.ts
+++ b/tests/release-process.test.ts
@@ -124,6 +124,16 @@ describe("Release process", () => {
 		);
 	});
 
+	it("binds the npm identity to a protected GitHub environment", () => {
+		const workflow = readText("../.github/workflows/release.yml");
+		const guide = readText("../docs/releases.md");
+
+		expect(workflow).toContain("    environment:\n      name: npm");
+		expect(workflow).toContain("if: github.ref == 'refs/heads/main'");
+		expect(guide).toContain("- Environment: `npm`");
+		expect(guide).toContain("allows only the `main` branch");
+	});
+
 	it("documents publication targets, npm setup, and emergency recovery", () => {
 		const guide = readText("../docs/releases.md");
 

--- a/tests/release-publishing.test.ts
+++ b/tests/release-publishing.test.ts
@@ -1,0 +1,209 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	publishPackage,
+	runPublishCommand,
+} from "../scripts/publish-package.mjs";
+import {
+	assertReleaseState,
+	getTargetDistTag,
+} from "../scripts/release-state.mjs";
+import { runVerifyCommand } from "../scripts/verify-release.mjs";
+
+describe("Release publishing", () => {
+	it("maps supported versions to explicit npm dist-tags", () => {
+		expect(getTargetDistTag("1.0.0-rc.8")).toBe("rc");
+		expect(getTargetDistTag("1.0.0")).toBe("latest");
+		expect(() => getTargetDistTag("1.0.0-beta.1")).toThrow(
+			"Unsupported prerelease version",
+		);
+	});
+
+	it("reconciles package metadata, npm, and the workflow result", () => {
+		const release = {
+			packageName: "@shirudo/kizuna",
+			packageVersion: "1.0.0-rc.8",
+			jsrVersion: "1.0.0-rc.8",
+			npmVersion: "1.0.0-rc.8",
+			distTags: { latest: "0.0.15", rc: "1.0.0-rc.8" },
+			published: true,
+			publishedPackages: [{ name: "@shirudo/kizuna", version: "1.0.0-rc.8" }],
+		};
+
+		expect(() => assertReleaseState(release)).not.toThrow();
+
+		expect(() =>
+			assertReleaseState({
+				...release,
+				jsrVersion: "1.0.0-rc.7",
+				npmVersion: "1.0.0-rc.7",
+				distTags: { latest: "0.0.15", rc: "1.0.0-rc.7" },
+				publishedPackages: [],
+			}),
+		).toThrowError(
+			/.*jsr\.json.*\n.*npm version.*\n.*npm dist-tag.*\n.*workflow output.*/s,
+		);
+	});
+
+	it("publishes an unpublished version with its target dist-tag", async () => {
+		const publishCalls: string[] = [];
+
+		const result = await publishPackage({
+			packageName: "@shirudo/kizuna",
+			packageVersion: "1.0.0-rc.8",
+			isPublished: async () => false,
+			publish: async (distTag: string) => publishCalls.push(distTag),
+		});
+
+		expect(result).toEqual({
+			published: true,
+			distTag: "rc",
+			packageName: "@shirudo/kizuna",
+			packageVersion: "1.0.0-rc.8",
+		});
+		expect(publishCalls).toEqual(["rc"]);
+	});
+
+	it("does not publish a version that already exists", async () => {
+		const result = await publishPackage({
+			packageName: "@shirudo/kizuna",
+			packageVersion: "1.0.0",
+			isPublished: async () => true,
+			publish: async () => {
+				throw new Error("publish must not run");
+			},
+		});
+
+		expect(result).toMatchObject({ published: false, distTag: "latest" });
+	});
+
+	it("uses npm CLI so trusted publishing can create provenance", async () => {
+		const root = mkdtempSync(join(tmpdir(), "kizuna-publish-"));
+		const calls: string[][] = [];
+		const commands: string[] = [];
+		const logs: string[] = [];
+
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "@shirudo/kizuna", version: "1.0.0-rc.8" }),
+			);
+
+			await runPublishCommand({
+				root,
+				execute: async (command: string, args: string[]) => {
+					commands.push(command);
+					calls.push(args);
+
+					if (args[0] === "view") {
+						throw Object.assign(new Error("Not found"), {
+							stderr: "npm error code E404",
+						});
+					}
+
+					return { stdout: "{}", stderr: "" };
+				},
+				log: (message: string) => logs.push(message),
+			});
+
+			expect(calls).toEqual([
+				["view", "@shirudo/kizuna@1.0.0-rc.8", "version", "--json"],
+				[
+					"publish",
+					"--access",
+					"public",
+					"--tag",
+					"rc",
+					"--provenance",
+					"--json",
+				],
+			]);
+			expect(commands).toEqual(["npm", "npm"]);
+			expect(logs).toContain("New tag: @shirudo/kizuna@1.0.0-rc.8");
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("verifies the published package against npm", async () => {
+		const root = mkdtempSync(join(tmpdir(), "kizuna-verify-"));
+		const calls: string[][] = [];
+		const logs: string[] = [];
+
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "@shirudo/kizuna", version: "1.0.0-rc.8" }),
+			);
+			writeFileSync(
+				join(root, "jsr.json"),
+				JSON.stringify({ name: "@shirudo/kizuna", version: "1.0.0-rc.8" }),
+			);
+
+			await runVerifyCommand({
+				root,
+				published: "true",
+				publishedPackages: JSON.stringify([
+					{ name: "@shirudo/kizuna", version: "1.0.0-rc.8" },
+				]),
+				execute: async (_command: string, args: string[]) => {
+					calls.push(args);
+
+					return {
+						stdout:
+							args[2] === "dist-tags"
+								? JSON.stringify({ latest: "0.0.15", rc: "1.0.0-rc.8" })
+								: JSON.stringify("1.0.0-rc.8"),
+						stderr: "",
+					};
+				},
+				log: (message: string) => logs.push(message),
+			});
+
+			expect(calls).toEqual([
+				["view", "@shirudo/kizuna@1.0.0-rc.8", "version", "--json"],
+				["view", "@shirudo/kizuna", "dist-tags", "--json"],
+			]);
+			expect(logs).toContain(
+				"Verified @shirudo/kizuna@1.0.0-rc.8 on npm with dist-tag rc.",
+			);
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+
+	it("accepts empty action outputs when the current version is already published", async () => {
+		const root = mkdtempSync(join(tmpdir(), "kizuna-verify-existing-"));
+
+		try {
+			writeFileSync(
+				join(root, "package.json"),
+				JSON.stringify({ name: "@shirudo/kizuna", version: "1.0.0" }),
+			);
+			writeFileSync(
+				join(root, "jsr.json"),
+				JSON.stringify({ name: "@shirudo/kizuna", version: "1.0.0" }),
+			);
+
+			await expect(
+				runVerifyCommand({
+					root,
+					published: "",
+					publishedPackages: "",
+					execute: async (_command: string, args: string[]) => ({
+						stdout:
+							args[2] === "dist-tags"
+								? JSON.stringify({ latest: "1.0.0" })
+								: JSON.stringify("1.0.0"),
+						stderr: "",
+					}),
+					log: () => undefined,
+				}),
+			).resolves.toBeUndefined();
+		} finally {
+			rmSync(root, { recursive: true, force: true });
+		}
+	});
+});


### PR DESCRIPTION
## Summary

- publish unpublished package versions through npm trusted publishing
- map release candidates to `rc` and stable versions to `latest`
- verify `package.json`, `jsr.json`, npm, dist-tags, and Changesets outputs
- bind the OIDC identity to the protected `npm` environment and `main` branch
- document the npm setup and emergency release path

## Publishing configuration

The npm trusted publisher for `@shirudo/kizuna` is configured with:

- GitHub owner: `shi-rudo`
- Repository: `kizuna`
- Workflow: `release.yml`
- Environment: `npm`
- Allowed action: `npm publish`

The GitHub Environment `npm` has a deployment branch policy that allows only `main`.

The live npm registry still has `rc=1.0.0-rc.3`. The repository is at `1.0.0-rc.8`, so the first successful workflow run will publish that missing version.

## Verification

- `./node_modules/.bin/vitest run` — 253 tests passed
- `./node_modules/.bin/tsc -p tsconfig.type-tests.json`
- `./node_modules/.bin/tsup && ./node_modules/.bin/tsc -p tsconfig.json --emitDeclarationOnly`
- scoped Biome checks and `git diff --check`
- release workflow parses as valid YAML
- GitHub Environment `npm` has one branch policy: `main`

No changeset is included because this change affects release infrastructure, not the package API or runtime behavior.

Bead: `kizuna-5da.7.3`
