### PR TITLE
fix(release): create tags before Changesets pushes them

### DIFF
--- a/scripts/publish-package.mjs
+++ b/scripts/publish-package.mjs
@@ -96,6 +96,7 @@ export const runPublishCommand = async ({
 	});
 
 	if (result.published) {
+		await execute("git", ["tag", `v${packageVersion}`], { cwd: root });
 		log(`New tag: ${selector}`);
 	} else {
 		log(`${selector} is already published.`);

--- a/tests/release-publishing.test.ts
+++ b/tests/release-publishing.test.ts
@@ -119,8 +119,9 @@ describe("Release publishing", () => {
 					"--provenance",
 					"--json",
 				],
+				["tag", "v1.0.0-rc.8"],
 			]);
-			expect(commands).toEqual(["npm", "npm"]);
+			expect(commands).toEqual(["npm", "npm", "git"]);
 			expect(logs).toContain("New tag: @shirudo/kizuna@1.0.0-rc.8");
 		} finally {
 			rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- create the local version tag after npm accepts a package
- let `changesets/action` push that tag and create the GitHub release
- cover the required command sequence with a regression test

## Verification

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc -p tsconfig.type-tests.json`
- `./node_modules/.bin/tsup && ./node_modules/.bin/tsc -p tsconfig.json --emitDeclarationOnly`
- `./node_modules/.bin/biome check scripts/publish-package.mjs tests/release-publishing.test.ts`

Tracks kizuna-5da.7.3.
