### PR TITLE
fix(types): validate constructor dependency keys

### DIFF
--- a/.changeset/typed-constructor-dependencies.md
+++ b/.changeset/typed-constructor-dependencies.md
@@ -1,0 +1,9 @@
+---
+"@shirudo/kizuna": major
+---
+
+Type-check concrete constructor dependency keys against registered service types and constructor parameter positions. Register each dependency before its consumer.
+
+Fix keys whose service type does not match the parameter at the same position. Remove missing or additional keys.
+
+The second generic argument now represents the constructor type. Remove explicit instance-type arguments, or replace them with `typeof Service`.

--- a/.changeset/typed-constructor-dependencies.md
+++ b/.changeset/typed-constructor-dependencies.md
@@ -12,4 +12,4 @@ Require one fixed string literal for each concrete constructor registration key.
 
 Prevent a root builder from declaring services that do not exist in its runtime registry.
 
-Check up to ten public constructor overloads. Accept each declared parameter tuple and preserve different result types as a union.
+Check public constructor overloads without a fixed library limit. Accept each declared parameter tuple and preserve different result types as a union.

--- a/.changeset/typed-constructor-dependencies.md
+++ b/.changeset/typed-constructor-dependencies.md
@@ -7,3 +7,9 @@ Type-check concrete constructor dependency keys against registered service types
 Fix keys whose service type does not match the parameter at the same position. Remove missing or additional keys.
 
 The second generic argument now represents the constructor type. Remove explicit instance-type arguments, or replace them with `typeof Service`.
+
+Require one fixed string literal for each concrete constructor registration key. Reject broad strings, unions, and open template patterns.
+
+Prevent a root builder from declaring services that do not exist in its runtime registry.
+
+Check up to ten public constructor overloads. Accept each declared parameter tuple and preserve different result types as a union.

--- a/README.md
+++ b/README.md
@@ -70,7 +70,9 @@ Each registration key must be one fixed string literal. Broad strings, unions, a
 
 A root builder starts with an empty registry. Do not supply a populated registry type to its constructor.
 
-Kizuna checks up to ten public constructor overloads. Any declared parameter tuple is valid. Different overload result types produce a union.
+Kizuna checks each public constructor overload. Kizuna does not set a fixed overload count. TypeScript compiler limits still apply.
+
+Any declared parameter tuple is valid. Different overload result types produce a union.
 
 ```typescript
 const container = new ContainerBuilder()

--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ For services with constructor dependencies:
 
 TypeScript checks each dependency key against the constructor parameter at the same position. Register each dependency before its consumer.
 
+Each registration key must be one fixed string literal. Broad strings, unions, and open template patterns fail compilation.
+
+A root builder starts with an empty registry. Do not supply a populated registry type to its constructor.
+
+Kizuna checks up to ten public constructor overloads. Any declared parameter tuple is valid. Different overload result types produce a union.
+
 ```typescript
 const container = new ContainerBuilder()
   .registerSingleton('Config', ConfigService)
@@ -494,30 +500,30 @@ The main class for configuring your dependency injection container.
 
 ```typescript
 // Singleton lifecycle
-.registerSingleton<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.registerSingleton<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
 .registerSingletonInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerSingletonFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 
 // Scoped lifecycle (one instance per scope)
-.registerScoped<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.registerScoped<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
 .registerScopedInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerScopedFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 
 // Transient lifecycle (new instance every time)
-.registerTransient<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.registerTransient<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
 .registerTransientInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerTransientFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 ```
 
-`DependencyKeys` is an internal type. The builder infers it from the current registry and the constructor parameters.
+`LiteralServiceKey`, `ConstructorParameterTuples`, and `DependencyKeys` are internal types. The builder infers them from each call.
 
 #### Multi-Registration Methods
 
 ```typescript
 // Append services under a shared key (resolved via getAll())
-.addSingleton<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
-.addScoped<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
-.addTransient<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.addSingleton<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
+.addScoped<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
+.addTransient<K, TCtor>(key: LiteralServiceKey<K>, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>)
 .addSingletonFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 .addScopedFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 .addTransientFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ class UserService {
 // 🎯 Register services with full type safety
 const container = new ContainerBuilder()
   .registerSingleton('Logger', Logger)                      // Type: Logger ✨
-  .registerSingleton('Database', DatabaseService, 'Logger') // Dependencies as strings
+  .registerSingleton('Database', DatabaseService, 'Logger') // Typed dependency key
   .registerScoped('UserService', UserService, 'Database', 'Logger')
   .build();
 
@@ -64,16 +64,20 @@ Kizuna provides a single, comprehensive API that combines type safety and flexib
 
 For services with constructor dependencies:
 
+TypeScript checks each dependency key against the constructor parameter at the same position. Register each dependency before its consumer.
+
 ```typescript
 const container = new ContainerBuilder()
   .registerSingleton('Config', ConfigService)
-  .registerScoped('UserService', UserService, 'Config')      // Dependencies as strings
+  .registerScoped('UserService', UserService, 'Config')      // 'Config' must provide the first parameter type
   .registerTransient('EmailService', EmailService, 'Config')
   .build();
 
 // IDE suggests: 'Config', 'UserService', 'EmailService'
 const userService = container.get('UserService'); // Type: UserService ✨
 ```
+
+If an existing registration fails compilation, read the [typed constructor dependency migration](./docs/migrations/typed-constructor-dependencies.md).
 
 ### 🎯 **Interface Registration** (For Abstractions)
 
@@ -246,63 +250,40 @@ if (issues.length === 0) {
 }
 ```
 
-### 🎯 **Strict Parameter Validation**
+### 🎯 **Constructor Dependency Checks**
 
-Kizuna automatically validates that your dependency names match constructor parameter names, preventing runtime errors from incorrect dependency order:
+TypeScript checks the dependency count, type, and position for concrete constructor registrations:
 
 ```typescript
+class Logger {}
+class MailService {}
+
 class EmailService {
-  // Constructor parameters: logger, mailer
   constructor(private logger: Logger, private mailer: MailService) {}
 }
 
-// ❌ Wrong parameter order - will fail validation
 const builder = new ContainerBuilder()
-  .registerSingleton('Logger', Logger)
-  .registerSingleton('MailService', MailService, 'Logger')
-  .registerScoped('EmailService', EmailService, 'MailService', 'Logger'); // Wrong order!
+  .registerSingleton('logger', Logger)
+  .registerSingleton('mailer', MailService)
+  .registerScoped('emailService', EmailService, 'logger', 'mailer');
 
-const issues = builder.validate();
-// Returns: [
-//   "Service 'EmailService' parameter 0 is named 'logger' but dependency 'MailService' is provided",
-//   "Service 'EmailService' parameter 1 is named 'mailer' but dependency 'Logger' is provided"
-// ]
-
-// ✅ Correct parameter order - validation passes
-const correctBuilder = new ContainerBuilder()
-  .registerSingleton('Logger', Logger)
-  .registerSingleton('MailService', MailService, 'Logger')
-  .registerScoped('EmailService', EmailService, 'logger', 'mailer'); // Matches constructor!
-
-correctBuilder.validate(); // Returns: [] (no issues)
+// TypeScript error: 'mailer' does not provide the Logger parameter.
+builder.registerScoped('brokenEmailService', EmailService, 'mailer', 'logger');
 ```
 
-**Benefits:**
-- **Helps Prevent Runtime Errors**: Catches dependency order mismatches at validation time
-- **Enabled by Default in Development**: Works automatically; auto-disabled in production (`NODE_ENV=production`) because minification mangles parameter names and the check would produce false positives
-- **Helpful Suggestions**: Provides corrected registration examples in error messages
-- **Opt-out Available**: Can be disabled explicitly with `.disableStrictParameterValidation()` (useful if you want to disable it in development too)
+This check applies to `registerSingleton`, `registerScoped`, `registerTransient`, and their constructor-based `add*` methods.
 
-**When Parameter Validation Helps:**
-```typescript
-// Before: Runtime error when EmailService tries to use dependencies
-class EmailService {
-  constructor(private logger: Logger, private config: ConfigService) {}
-  
-  sendEmail() {
-    this.logger.log('Sending email...'); // 💥 Runtime error if dependencies swapped!
-  }
-}
+In development, strict parameter validation also compares each key with the source parameter name. This additional check can find naming mistakes.
 
-// After: Validation catches the error before runtime
-builder.validate(); // Catches parameter name mismatches early
-```
+Production mode disables the name check because minifiers can change parameter names. The TypeScript type check does not depend on parameter names.
 
-**Disable if needed** (not recommended):
+If your key names and parameter names differ, disable only the parameter-name check:
 ```typescript
 const container = new ContainerBuilder()
-  .disableStrictParameterValidation() // Turn off validation
-  .registerScoped('EmailService', EmailService, 'config', 'logger') // Order doesn't matter
+  .disableStrictParameterValidation()
+  .registerSingleton('loggerService', Logger)
+  .registerSingleton('mailService', MailService)
+  .registerScoped('emailService', EmailService, 'loggerService', 'mailService')
   .build();
 ```
 
@@ -513,28 +494,30 @@ The main class for configuring your dependency injection container.
 
 ```typescript
 // Singleton lifecycle
-.registerSingleton<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
+.registerSingleton<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
 .registerSingletonInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerSingletonFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 
 // Scoped lifecycle (one instance per scope)
-.registerScoped<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
+.registerScoped<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
 .registerScopedInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerScopedFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 
 // Transient lifecycle (new instance every time)
-.registerTransient<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
+.registerTransient<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
 .registerTransientInterface<T, K>(key: K, implementationType: new (...args: any[]) => T, ...dependencies: string[])
 .registerTransientFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 ```
+
+`DependencyKeys` is an internal type. The builder infers it from the current registry and the constructor parameters.
 
 #### Multi-Registration Methods
 
 ```typescript
 // Append services under a shared key (resolved via getAll())
-.addSingleton<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
-.addScoped<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
-.addTransient<K, T>(key: K, serviceType: new (...args: any[]) => T, ...dependencies: string[])
+.addSingleton<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.addScoped<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
+.addTransient<K, TCtor>(key: K, serviceType: TCtor, ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>)
 .addSingletonFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 .addScopedFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)
 .addTransientFactory<K, T>(key: K, factory: (provider: TypeSafeServiceLocator<TRegistry>) => T)

--- a/docs/migrations/typed-constructor-dependencies.md
+++ b/docs/migrations/typed-constructor-dependencies.md
@@ -1,0 +1,66 @@
+# Typed constructor dependency keys
+
+Kizuna now checks concrete constructor dependency keys during TypeScript compilation.
+
+This change affects these methods:
+
+- `registerSingleton`
+- `registerScoped`
+- `registerTransient`
+- `addSingleton`
+- `addScoped`
+- `addTransient`
+
+Each dependency key must identify a registered service. The service type must match the constructor parameter at the same position.
+
+Register each dependency before you register its consumer. TypeScript uses the current builder registry for the check.
+
+## Migration
+
+This registration compiled before the change, but it supplied the dependencies in the wrong order:
+
+```typescript
+class Service {
+  constructor(readonly logger: Logger, readonly config: Config) {}
+}
+
+const builder = new ContainerBuilder()
+  .registerSingleton('logger', Logger)
+  .registerSingleton('config', Config)
+  .registerScoped('service', Service, 'config', 'logger');
+```
+
+Use keys that match the constructor parameter order:
+
+```typescript
+const builder = new ContainerBuilder()
+  .registerSingleton('logger', Logger)
+  .registerSingleton('config', Config)
+  .registerScoped('service', Service, 'logger', 'config');
+```
+
+If TypeScript reports an error, make these changes:
+
+1. Register each dependency before its consumer.
+2. Put the dependency keys in the constructor parameter order.
+3. Add one key for each required parameter.
+4. Remove keys that do not have a constructor parameter.
+5. Use a key whose service type is assignable to the parameter type.
+
+Optional constructor parameters accept zero or one matching key. Rest parameters accept zero or more matching keys.
+
+TypeScript uses structural types for this check. Services with the same structure are compatible even when they use different class names.
+
+The second generic argument now represents the constructor type. Remove explicit instance-type arguments and use inference:
+
+```typescript
+// Before
+builder.registerSingleton<'service', Service>('service', Service);
+
+// After
+builder.registerSingleton('service', Service);
+```
+
+If inference is not possible, use `typeof Service` as the second generic argument.
+
+Interface registration methods are not part of this change. Their explicit interface type continues to define the provider result.

--- a/docs/migrations/typed-constructor-dependencies.md
+++ b/docs/migrations/typed-constructor-dependencies.md
@@ -63,4 +63,43 @@ builder.registerSingleton('service', Service);
 
 If inference is not possible, use `typeof Service` as the second generic argument.
 
+## Use one fixed registration key
+
+Concrete constructor registration methods now require one fixed string literal. Broad strings, unions, and open template patterns fail compilation.
+
+Keep a computed key narrow with `as const`:
+
+```typescript
+// Before: key has type string
+const key = getServiceKey();
+builder.registerSingleton(key, Service);
+
+// After: key has one fixed literal type
+const key = 'service' as const;
+builder.registerSingleton(key, Service);
+```
+
+This rule prevents the type registry from listing keys that the runtime registry does not contain.
+
+## Start with an empty root registry
+
+A root builder always starts with an empty runtime registry. Do not supply a populated registry type:
+
+```typescript
+// Before
+const builder = new ContainerBuilder<{ logger: Logger }>();
+
+// After
+const builder = new ContainerBuilder()
+  .registerSingleton('logger', Logger);
+```
+
+Let each registration add its service to the inferred registry type.
+
+## Check overloaded constructors
+
+Kizuna checks up to ten public constructor overloads. A dependency list can match any declared overload.
+
+If overloads return different service types, the provider result is a union of those types.
+
 Interface registration methods are not part of this change. Their explicit interface type continues to define the provider result.

--- a/docs/migrations/typed-constructor-dependencies.md
+++ b/docs/migrations/typed-constructor-dependencies.md
@@ -98,7 +98,9 @@ Let each registration add its service to the inferred registry type.
 
 ## Check overloaded constructors
 
-Kizuna checks up to ten public constructor overloads. A dependency list can match any declared overload.
+Kizuna checks each public constructor overload. Kizuna does not set a fixed overload count. TypeScript compiler limits still apply.
+
+A dependency list can match any declared overload.
 
 If overloads return different service types, the provider result is a union of those types.
 

--- a/src/api/container-builder.ts
+++ b/src/api/container-builder.ts
@@ -49,30 +49,34 @@ type LiteralServiceKey<K extends string> = IsFixedStringLiteral<K> extends true
 
 type ServiceConstructor = new (...args: any[]) => any;
 
-/** Extracts up to ten public constructor overloads without runtime work. */
-type ConstructorOverloads<TCtor> = TCtor extends {
-    new (...args: infer A1): infer R1;
-    new (...args: infer A2): infer R2;
-    new (...args: infer A3): infer R3;
-    new (...args: infer A4): infer R4;
-    new (...args: infer A5): infer R5;
-    new (...args: infer A6): infer R6;
-    new (...args: infer A7): infer R7;
-    new (...args: infer A8): infer R8;
-    new (...args: infer A9): infer R9;
-    new (...args: infer A10): infer R10;
-}
-    ? | (new (...args: A1) => R1)
-      | (new (...args: A2) => R2)
-      | (new (...args: A3) => R3)
-      | (new (...args: A4) => R4)
-      | (new (...args: A5) => R5)
-      | (new (...args: A6) => R6)
-      | (new (...args: A7) => R7)
-      | (new (...args: A8) => R8)
-      | (new (...args: A9) => R9)
-      | (new (...args: A10) => R10)
-    : TCtor;
+type IsSameType<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() =>
+    T extends B ? 1 : 2)
+    ? (<T>() => T extends B ? 1 : 2) extends (<T>() => T extends A ? 1 : 2)
+        ? true
+        : false
+    : false;
+
+type MatchingSeenSignature<TSeen, TSignature> = TSeen extends unknown
+    ? IsSameType<TSeen, TSignature>
+    : never;
+
+/** Rotates the final visible overload until the inferred signature repeats. */
+type InternalConstructorSignatures<TCtor, TSeen = never> =
+    TCtor extends new (...args: infer TParameters) => infer TResult
+        ? true extends MatchingSeenSignature<
+              TSeen,
+              new (...args: TParameters) => TResult
+          >
+            ? never
+            : | (new (...args: TParameters) => TResult)
+              | InternalConstructorSignatures<
+                    (new (...args: TParameters) => TResult) & TCtor,
+                    TSeen | (new (...args: TParameters) => TResult)
+                >
+        : never;
+
+/** Converts public constructor overloads to a union without a library-defined limit. */
+type ConstructorOverloads<TCtor> = InternalConstructorSignatures<TCtor>;
 
 type ParametersOf<TCtor> = TCtor extends ServiceConstructor
     ? ConstructorParameters<TCtor>

--- a/src/api/container-builder.ts
+++ b/src/api/container-builder.ts
@@ -49,6 +49,47 @@ type LiteralServiceKey<K extends string> = IsFixedStringLiteral<K> extends true
 
 type ServiceConstructor = new (...args: any[]) => any;
 
+/** Extracts up to ten public constructor overloads without runtime work. */
+type ConstructorOverloads<TCtor> = TCtor extends {
+    new (...args: infer A1): infer R1;
+    new (...args: infer A2): infer R2;
+    new (...args: infer A3): infer R3;
+    new (...args: infer A4): infer R4;
+    new (...args: infer A5): infer R5;
+    new (...args: infer A6): infer R6;
+    new (...args: infer A7): infer R7;
+    new (...args: infer A8): infer R8;
+    new (...args: infer A9): infer R9;
+    new (...args: infer A10): infer R10;
+}
+    ? | (new (...args: A1) => R1)
+      | (new (...args: A2) => R2)
+      | (new (...args: A3) => R3)
+      | (new (...args: A4) => R4)
+      | (new (...args: A5) => R5)
+      | (new (...args: A6) => R6)
+      | (new (...args: A7) => R7)
+      | (new (...args: A8) => R8)
+      | (new (...args: A9) => R9)
+      | (new (...args: A10) => R10)
+    : TCtor;
+
+type ParametersOf<TCtor> = TCtor extends ServiceConstructor
+    ? ConstructorParameters<TCtor>
+    : never;
+
+type InstanceOf<TCtor> = TCtor extends ServiceConstructor
+    ? InstanceType<TCtor>
+    : never;
+
+type ConstructorParameterTuples<TCtor extends ServiceConstructor> = ParametersOf<
+    ConstructorOverloads<TCtor>
+>;
+
+type ConstructedService<TCtor extends ServiceConstructor> = InstanceOf<
+    ConstructorOverloads<TCtor>
+>;
+
 type MatchingDependencyKey<TRegistry, TParameter> = {
     [K in Extract<keyof TRegistry, string>]: TRegistry[K] extends TParameter
         ? K
@@ -106,6 +147,11 @@ type DependencyKeys<
  *
  */
 export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends BaseContainerBuilder {
+    /** Creates a root builder with an empty service registry. */
+    constructor(..._rootRegistryOnly: keyof TRegistry extends never ? [] : [never]) {
+        super();
+    }
+
     // =================
     // CONSTRUCTOR-BASED REGISTRATION
     // =================
@@ -113,20 +159,20 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
     /**
      * Registers a service with singleton lifetime using constructor and dependencies.
      * 
-     * @template K - The string key for the service
+     * @template K - One fixed string key for the service
      * @template TCtor - The service constructor type
-     * @param key - The string key used to identify the service
+     * @param key - One fixed string key that identifies the service
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     registerSingleton<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
-        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, ConstructedService<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<ConstructedService<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new SingletonLifecycle());
@@ -135,20 +181,20 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
     /**
      * Registers a service with scoped lifetime using constructor and dependencies.
      * 
-     * @template K - The string key for the service
+     * @template K - One fixed string key for the service
      * @template TCtor - The service constructor type
-     * @param key - The string key used to identify the service
+     * @param key - One fixed string key that identifies the service
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     registerScoped<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
-        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, ConstructedService<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<ConstructedService<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new ScopedLifecycle());
@@ -157,20 +203,20 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
     /**
      * Registers a service with transient lifetime using constructor and dependencies.
      * 
-     * @template K - The string key for the service
+     * @template K - One fixed string key for the service
      * @template TCtor - The service constructor type
-     * @param key - The string key used to identify the service
+     * @param key - One fixed string key that identifies the service
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     registerTransient<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
-        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, ConstructedService<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<ConstructedService<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new TransientLifecycle());
@@ -316,20 +362,25 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Multiple services can be registered under the same key and resolved together via `getAll()`.
      * Cannot be mixed with `register*()` for the same key.
      *
-     * @template K - The string key for the multi-registration
+     * @template K - One fixed string key for the multi-registration
      * @template TCtor - The service constructor type
-     * @param key - The shared key for this group of services
+     * @param key - One fixed string key for this group of services
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     addSingleton<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
-        return this.addTypeSafe(key, serviceType, dependencies, new SingletonLifecycle());
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, ConstructedService<TCtor>>> {
+        return this.addTypeSafe<K, ConstructedService<TCtor>>(
+            key,
+            serviceType,
+            dependencies,
+            new SingletonLifecycle(),
+        );
     }
 
     /**
@@ -337,20 +388,25 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Multiple services can be registered under the same key and resolved together via `getAll()`.
      * Cannot be mixed with `register*()` for the same key.
      *
-     * @template K - The string key for the multi-registration
+     * @template K - One fixed string key for the multi-registration
      * @template TCtor - The service constructor type
-     * @param key - The shared key for this group of services
+     * @param key - One fixed string key for this group of services
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     addScoped<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
-        return this.addTypeSafe(key, serviceType, dependencies, new ScopedLifecycle());
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, ConstructedService<TCtor>>> {
+        return this.addTypeSafe<K, ConstructedService<TCtor>>(
+            key,
+            serviceType,
+            dependencies,
+            new ScopedLifecycle(),
+        );
     }
 
     /**
@@ -358,20 +414,25 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Multiple services can be registered under the same key and resolved together via `getAll()`.
      * Cannot be mixed with `register*()` for the same key.
      *
-     * @template K - The string key for the multi-registration
+     * @template K - One fixed string key for the multi-registration
      * @template TCtor - The service constructor type
-     * @param key - The shared key for this group of services
+     * @param key - One fixed string key for this group of services
      * @param serviceType - The service constructor
      * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
      * @remarks Register each dependency before you use its key in this method.
      */
     addTransient<K extends string, TCtor extends ServiceConstructor>(
-        key: K,
+        key: LiteralServiceKey<K>,
         serviceType: TCtor,
-        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
-        return this.addTypeSafe(key, serviceType, dependencies, new TransientLifecycle());
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameterTuples<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, ConstructedService<TCtor>>> {
+        return this.addTypeSafe<K, ConstructedService<TCtor>>(
+            key,
+            serviceType,
+            dependencies,
+            new TransientLifecycle(),
+        );
     }
 
     /**

--- a/src/api/container-builder.ts
+++ b/src/api/container-builder.ts
@@ -47,6 +47,21 @@ type LiteralServiceKey<K extends string> = IsFixedStringLiteral<K> extends true
     ? K
     : never;
 
+type ServiceConstructor = new (...args: any[]) => any;
+
+type MatchingDependencyKey<TRegistry, TParameter> = {
+    [K in Extract<keyof TRegistry, string>]: TRegistry[K] extends TParameter
+        ? K
+        : never;
+}[Extract<keyof TRegistry, string>];
+
+type DependencyKeys<
+    TRegistry,
+    TParameters extends readonly unknown[],
+> = {
+    [I in keyof TParameters]: MatchingDependencyKey<TRegistry, TParameters[I]>;
+};
+
 /**
  * ContainerBuilder provides a unified, fully type-safe API for dependency injection.
  * Combines all registration patterns with complete type safety and IDE autocompletion.
@@ -99,18 +114,19 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Registers a service with singleton lifetime using constructor and dependencies.
      * 
      * @template K - The string key for the service
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The string key used to identify the service
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    registerSingleton<K extends string, T>(
+    registerSingleton<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<TRegistry & Record<K, T>> {
-        const configurator = (registrar: TypeSafeRegistrar<T>) => {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new SingletonLifecycle());
@@ -120,18 +136,19 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Registers a service with scoped lifetime using constructor and dependencies.
      * 
      * @template K - The string key for the service
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The string key used to identify the service
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    registerScoped<K extends string, T>(
+    registerScoped<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<TRegistry & Record<K, T>> {
-        const configurator = (registrar: TypeSafeRegistrar<T>) => {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new ScopedLifecycle());
@@ -141,18 +158,19 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Registers a service with transient lifetime using constructor and dependencies.
      * 
      * @template K - The string key for the service
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The string key used to identify the service
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    registerTransient<K extends string, T>(
+    registerTransient<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<TRegistry & Record<K, T>> {
-        const configurator = (registrar: TypeSafeRegistrar<T>) => {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<TRegistry & Record<K, InstanceType<TCtor>>> {
+        const configurator = (registrar: TypeSafeRegistrar<InstanceType<TCtor>>) => {
             registrar.useType(serviceType, ...dependencies);
         };
         return this.registerTypeSafe(key, configurator, new TransientLifecycle());
@@ -299,17 +317,18 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Cannot be mixed with `register*()` for the same key.
      *
      * @template K - The string key for the multi-registration
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The shared key for this group of services
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    addSingleton<K extends string, T>(
+    addSingleton<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, T>> {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
         return this.addTypeSafe(key, serviceType, dependencies, new SingletonLifecycle());
     }
 
@@ -319,17 +338,18 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Cannot be mixed with `register*()` for the same key.
      *
      * @template K - The string key for the multi-registration
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The shared key for this group of services
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    addScoped<K extends string, T>(
+    addScoped<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, T>> {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
         return this.addTypeSafe(key, serviceType, dependencies, new ScopedLifecycle());
     }
 
@@ -339,17 +359,18 @@ export class ContainerBuilder<TRegistry extends ServiceRegistry = {}> extends Ba
      * Cannot be mixed with `register*()` for the same key.
      *
      * @template K - The string key for the multi-registration
-     * @template T - The service type (inferred from constructor)
+     * @template TCtor - The service constructor type
      * @param key - The shared key for this group of services
      * @param serviceType - The service constructor
-     * @param dependencies - Optional dependency keys
+     * @param dependencies - Keys that match the constructor parameters by type and position
      * @returns A new ContainerBuilder with the updated registry type
+     * @remarks Register each dependency before you use its key in this method.
      */
-    addTransient<K extends string, T>(
+    addTransient<K extends string, TCtor extends ServiceConstructor>(
         key: K,
-        serviceType: new (...args: any[]) => T,
-        ...dependencies: string[]
-    ): ContainerBuilder<AddToRegistry<TRegistry, K, T>> {
+        serviceType: TCtor,
+        ...dependencies: DependencyKeys<TRegistry, ConstructorParameters<TCtor>>
+    ): ContainerBuilder<AddToRegistry<TRegistry, K, InstanceType<TCtor>>> {
         return this.addTypeSafe(key, serviceType, dependencies, new TransientLifecycle());
     }
 

--- a/tests/constructor-dependencies.test-d.ts
+++ b/tests/constructor-dependencies.test-d.ts
@@ -13,6 +13,10 @@ class Config {
 	readonly kind = "config" as const;
 }
 
+class Feature {
+	readonly kind = "feature" as const;
+}
+
 class Consumer {
 	constructor(
 		readonly logger: LoggerContract,
@@ -29,6 +33,53 @@ class RestConsumer {
 		void loggers;
 	}
 }
+
+class OverloadedConsumer {
+	constructor(value: LoggerContract);
+	constructor(value: Config);
+	constructor(readonly value: LoggerContract | Config) {}
+}
+
+interface LoggerVariant {
+	readonly source: "logger";
+}
+
+interface ConfigVariant {
+	readonly source: "config";
+}
+
+interface VariantConstructor {
+	new (value: LoggerContract): LoggerVariant;
+	new (value: Config): ConfigVariant;
+}
+
+declare const VariantService: VariantConstructor;
+
+test("the root builder registry cannot be forged", () => {
+	// @ts-expect-error A root builder always starts with an empty runtime registry.
+	new ContainerBuilder<{ logger: Logger }>();
+});
+
+test("constructor registrations require one fixed service key", () => {
+	const broadKey = null as unknown as string;
+	const unionKey = null as unknown as "first" | "second";
+	const patternKey = null as unknown as `service:${string}`;
+
+	// @ts-expect-error A broad key would make every string appear registered.
+	new ContainerBuilder().registerSingleton(broadKey, Logger);
+	// @ts-expect-error A union would add a key that was not registered at runtime.
+	new ContainerBuilder().registerScoped(unionKey, Logger);
+	// @ts-expect-error An open pattern would add keys that were not registered at runtime.
+	new ContainerBuilder().registerTransient(patternKey, Logger);
+	// @ts-expect-error Constructor-based multi-registrations also reject broad keys.
+	new ContainerBuilder().addSingleton(broadKey, Logger);
+	// @ts-expect-error Constructor-based multi-registrations also reject union keys.
+	new ContainerBuilder().addScoped(unionKey, Logger);
+	// @ts-expect-error Constructor-based multi-registrations also reject open patterns.
+	new ContainerBuilder().addTransient(patternKey, Logger);
+
+	new ContainerBuilder().registerSingleton("service:123", Logger);
+});
 
 test("constructor dependency keys match parameter types and positions", () => {
 	const builder = new ContainerBuilder()
@@ -72,6 +123,32 @@ test("constructor dependency keys match parameter types and positions", () => {
 	builder.registerScoped("wrong-scoped", Consumer, "logger", "logger");
 	// @ts-expect-error Transient registrations reject the wrong dependency type.
 	builder.registerTransient("wrong-transient", Consumer, "config", "config");
+});
+
+test("constructor overloads accept every declared parameter tuple", () => {
+	const builder = new ContainerBuilder()
+		.registerSingleton("logger", Logger)
+		.registerSingleton("config", Config)
+		.registerSingleton("feature", Feature);
+
+	const provider = builder
+		.registerSingleton("logger-overload", OverloadedConsumer, "logger")
+		.registerSingleton("config-overload", OverloadedConsumer, "config")
+		.registerSingleton("variant", VariantService, "logger")
+		.build();
+
+	expectTypeOf(
+		provider.get("logger-overload"),
+	).toEqualTypeOf<OverloadedConsumer>();
+	expectTypeOf(
+		provider.get("config-overload"),
+	).toEqualTypeOf<OverloadedConsumer>();
+	expectTypeOf(provider.get("variant")).toEqualTypeOf<
+		LoggerVariant | ConfigVariant
+	>();
+
+	// @ts-expect-error No constructor overload accepts Feature.
+	builder.registerSingleton("invalid-overload", OverloadedConsumer, "feature");
 });
 
 test("optional and rest constructor parameters keep their tuple semantics", () => {

--- a/tests/constructor-dependencies.test-d.ts
+++ b/tests/constructor-dependencies.test-d.ts
@@ -1,0 +1,106 @@
+import { expectTypeOf, test } from "vitest";
+import { ContainerBuilder } from "../src";
+
+interface LoggerContract {
+	readonly kind: "logger";
+}
+
+class Logger implements LoggerContract {
+	readonly kind = "logger" as const;
+}
+
+class Config {
+	readonly kind = "config" as const;
+}
+
+class Consumer {
+	constructor(
+		readonly logger: LoggerContract,
+		readonly config: Config,
+	) {}
+}
+
+class OptionalConsumer {
+	constructor(readonly logger?: LoggerContract) {}
+}
+
+class RestConsumer {
+	constructor(...loggers: LoggerContract[]) {
+		void loggers;
+	}
+}
+
+test("constructor dependency keys match parameter types and positions", () => {
+	const builder = new ContainerBuilder()
+		.registerSingleton("logger", Logger)
+		.registerSingleton("config", Config);
+
+	const provider = builder
+		.registerSingleton("singleton", Consumer, "logger", "config")
+		.registerScoped("scoped", Consumer, "logger", "config")
+		.registerTransient("transient", Consumer, "logger", "config")
+		.build();
+
+	expectTypeOf(provider.get("singleton")).toEqualTypeOf<Consumer>();
+	expectTypeOf(provider.get("scoped")).toEqualTypeOf<Consumer>();
+	expectTypeOf(provider.get("transient")).toEqualTypeOf<Consumer>();
+
+	builder.registerSingleton<"explicit", typeof Consumer>(
+		"explicit",
+		Consumer,
+		"logger",
+		"config",
+	);
+	// @ts-expect-error The second generic argument is the constructor type, not its instance type.
+	builder.registerSingleton<"old-explicit", Consumer>(
+		"old-explicit",
+		Consumer,
+		"logger",
+		"config",
+	);
+
+	// @ts-expect-error Unknown dependency keys must not compile.
+	builder.registerSingleton("unknown", Consumer, "logger", "missing");
+	// @ts-expect-error Dependency keys must follow the constructor parameter order.
+	builder.registerSingleton("wrong-order", Consumer, "config", "logger");
+	// @ts-expect-error Every required constructor parameter needs a dependency key.
+	builder.registerSingleton("missing", Consumer, "logger");
+	// @ts-expect-error Zero-argument constructors reject extra dependency keys.
+	builder.registerSingleton("extra", Logger, "config");
+
+	// @ts-expect-error Scoped registrations reject the wrong dependency type.
+	builder.registerScoped("wrong-scoped", Consumer, "logger", "logger");
+	// @ts-expect-error Transient registrations reject the wrong dependency type.
+	builder.registerTransient("wrong-transient", Consumer, "config", "config");
+});
+
+test("optional and rest constructor parameters keep their tuple semantics", () => {
+	const builder = new ContainerBuilder().registerSingleton("logger", Logger);
+
+	builder.registerSingleton("optional-empty", OptionalConsumer);
+	builder.registerSingleton("optional-value", OptionalConsumer, "logger");
+	builder.registerSingleton("rest-empty", RestConsumer);
+	builder.registerSingleton("rest-values", RestConsumer, "logger", "logger");
+
+	// @ts-expect-error Optional parameters still reject incompatible services.
+	builder.registerSingleton("optional-wrong", OptionalConsumer, "missing");
+	// @ts-expect-error Every rest dependency must match the rest parameter type.
+	builder.registerSingleton("rest-wrong", RestConsumer, "logger", "missing");
+});
+
+test("constructor-based multi-registrations use the same dependency checks", () => {
+	const builder = new ContainerBuilder()
+		.registerSingleton("logger", Logger)
+		.registerSingleton("config", Config);
+
+	builder.addSingleton("consumers", Consumer, "logger", "config");
+	builder.addScoped("consumers", Consumer, "logger", "config");
+	builder.addTransient("consumers", Consumer, "logger", "config");
+
+	// @ts-expect-error Singleton multi-registrations reject the wrong order.
+	builder.addSingleton("bad-singletons", Consumer, "config", "logger");
+	// @ts-expect-error Scoped multi-registrations reject missing dependencies.
+	builder.addScoped("bad-scoped", Consumer, "logger");
+	// @ts-expect-error Transient multi-registrations reject unknown dependencies.
+	builder.addTransient("bad-transients", Consumer, "logger", "missing");
+});

--- a/tests/constructor-dependencies.test-d.ts
+++ b/tests/constructor-dependencies.test-d.ts
@@ -40,6 +40,25 @@ class OverloadedConsumer {
 	constructor(readonly value: LoggerContract | Config) {}
 }
 
+type TaggedDependency<Tag extends string> = {
+	readonly tag: Tag;
+};
+
+class ElevenOverloadConsumer {
+	constructor(value: TaggedDependency<"one">);
+	constructor(value: TaggedDependency<"two">);
+	constructor(value: TaggedDependency<"three">);
+	constructor(value: TaggedDependency<"four">);
+	constructor(value: TaggedDependency<"five">);
+	constructor(value: TaggedDependency<"six">);
+	constructor(value: TaggedDependency<"seven">);
+	constructor(value: TaggedDependency<"eight">);
+	constructor(value: TaggedDependency<"nine">);
+	constructor(value: TaggedDependency<"ten">);
+	constructor(value: TaggedDependency<"eleven">);
+	constructor(readonly value: TaggedDependency<string>) {}
+}
+
 interface LoggerVariant {
 	readonly source: "logger";
 }
@@ -149,6 +168,44 @@ test("constructor overloads accept every declared parameter tuple", () => {
 
 	// @ts-expect-error No constructor overload accepts Feature.
 	builder.registerSingleton("invalid-overload", OverloadedConsumer, "feature");
+});
+
+test("constructor dependency checks accept overloads beyond the former limit", () => {
+	const builder = new ContainerBuilder()
+		.registerSingletonFactory("first-dependency", () => ({
+			tag: "one" as const,
+		}))
+		.registerSingletonFactory("last-dependency", () => ({
+			tag: "eleven" as const,
+		}));
+
+	const provider = builder
+		.registerSingleton(
+			"first-overload",
+			ElevenOverloadConsumer,
+			"first-dependency",
+		)
+		.registerSingleton(
+			"last-overload",
+			ElevenOverloadConsumer,
+			"last-dependency",
+		)
+		.build();
+
+	expectTypeOf(
+		provider.get("first-overload"),
+	).toEqualTypeOf<ElevenOverloadConsumer>();
+	expectTypeOf(
+		provider.get("last-overload"),
+	).toEqualTypeOf<ElevenOverloadConsumer>();
+});
+
+test("callable constructors keep their construct signatures", () => {
+	const provider = new ContainerBuilder()
+		.registerTransient("date", Date)
+		.build();
+
+	expectTypeOf(provider.get("date")).toEqualTypeOf<Date>();
 });
 
 test("optional and rest constructor parameters keep their tuple semantics", () => {


### PR DESCRIPTION
## Summary

- match concrete constructor dependency keys to parameter types and positions
- apply the same checks to singleton, scoped, transient, and constructor-based multi-registrations
- require one fixed literal key and reject forged root registry types
- preserve constructor parameter and result unions without a fixed library overload limit
- cover required, optional, rest, callable, and eleven-overload constructors with public type tests
- document the breaking migration and add the `1.0.0-rc.9` changeset

## Scope

Interface implementation dependencies remain separate because their explicit interface and key generics prevent partial constructor-type inference. Bead `kizuna-5da.1.6` tracks that API decision.

TypeScript compiler recursion limits still apply to unusually large overload sets.

## Verification

- `./node_modules/.bin/vitest run`
- `./node_modules/.bin/tsc -p tsconfig.type-tests.json`
- `./node_modules/.bin/tsup && ./node_modules/.bin/tsc -p tsconfig.json --emitDeclarationOnly`
- `./node_modules/.bin/biome lint src/api/container-builder.ts tests/constructor-dependencies.test-d.ts`
- `git diff --check`
- `./node_modules/.bin/changeset status`

Tracks `kizuna-5da.1.5`.
